### PR TITLE
Calibrate heatmap markers

### DIFF
--- a/static/js/viewer.js
+++ b/static/js/viewer.js
@@ -1455,7 +1455,9 @@ class STEPViewer {
 
         const box = new THREE.Box3().setFromObject(this.currentMesh);
         const size = box.getSize(new THREE.Vector3());
-        const markerSize = Math.max(size.x, size.y, size.z) * 0.01;
+        // Utilise 0.5 % de la diagonale du volume pour garder une taille cohérente quel que soit le modèle
+        const diag = Math.sqrt(size.x * size.x + size.y * size.y + size.z * size.z);
+        const markerSize = diag * 0.005;
 
         issues.forEach(issue => {
             const severity = issue.severity || 'info';


### PR DESCRIPTION
## Summary
- tweak `showHeatmapForCriterion` marker sizing based on model diagonal
- keep coordinates in millimeters for STL exports and analysis

## Testing
- `node --check static/js/viewer.js`


------
https://chatgpt.com/codex/tasks/task_e_6880b77779008333ac4e96824d37609e