### PR TITLE
Update viewer color refresh

### DIFF
--- a/static/js/viewer.js
+++ b/static/js/viewer.js
@@ -1442,6 +1442,7 @@ class STEPViewer {
             }
             geometry.attributes.color.needsUpdate = true;
             this.currentMesh.material.vertexColors = false;
+            this.currentMesh.material.needsUpdate = true;
         }
 
         this.highlightedFaceIndices = [];
@@ -1490,6 +1491,7 @@ class STEPViewer {
         }
 
         material.vertexColors = true;
+        material.needsUpdate = true;
 
         const colors = geometry.attributes.color.array;
 


### PR DESCRIPTION
## Summary
- force material refresh when clearing or setting vertex colors

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880c369e3588333b0a0dd2591384d89