### PR TITLE
Add heatmap generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from datetime import datetime
 from models import db, ConversionJob, UserSession, User, OAuth
 from dfm_analyzer import analyze_dfm, DFMReport
+from heatmap import generate_heatmap
 from material_recommender import recommend_materials_for_questionnaire
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
@@ -632,6 +633,9 @@ def analyze_dfm_endpoint(conversion_id):
                 'success': False,
                 'error': 'Fichier STEP non trouvé'
             }), 404
+
+        # STL path for heatmap generation
+        stl_path = os.path.join(app.config['CONVERTED_FOLDER'], conversion_job.stl_filename)
         
         # Check user authentication and credits
         if current_user.is_authenticated:
@@ -647,6 +651,7 @@ def analyze_dfm_endpoint(conversion_id):
         # Perform DFM analysis with proper error handling
         try:
             dfm_report = analyze_dfm(step_path, demolding_axis)
+            heatmap_data = generate_heatmap(stl_path)
             
             if dfm_report is None:
                 logger.error("DFM analysis returned None")
@@ -734,7 +739,8 @@ def analyze_dfm_endpoint(conversion_id):
                         'severity': str(issue.severity) if issue.severity else 'unknown',
                         'recommendation': str(issue.recommendation) if issue.recommendation else 'Recommandation non disponible'
                     } for issue in dfm_report.geometry_issues if issue
-                ]
+                ],
+                'heatmap': heatmap_data
             }
             
             # Test JSON serialization

--- a/heatmap.py
+++ b/heatmap.py
@@ -1,0 +1,53 @@
+"""Heatmap generation for STL files using trimesh.
+"""
+
+from typing import List, Dict
+import trimesh
+import numpy as np
+
+
+def generate_heatmap(stl_path: str) -> List[Dict[str, float]]:
+    """Analyze an STL file and return per-face defect severity.
+
+    Each dict in the returned list has the form::
+        {"face_index": int, "severity": float}
+
+    Severity is based on the maximum angular deviation between a face and
+    its neighbours. Values are expressed in degrees.
+    """
+    mesh = trimesh.load(stl_path, process=False)
+
+    if isinstance(mesh, trimesh.Scene):
+        # Take first geometry if a scene is loaded
+        if len(mesh.geometry) == 0:
+            return []
+        mesh = list(mesh.geometry.values())[0]
+
+    # Simplify very large meshes to keep processing fast
+    face_count = len(mesh.faces)
+    if face_count > 1_000_000:
+        try:
+            simplified = mesh.simplify_quadratic_decimation(1_000_000)
+            if simplified and len(simplified.faces) > 0:
+                mesh = simplified
+                face_count = len(mesh.faces)
+        except Exception:
+            pass
+
+    normals = mesh.face_normals
+    adjacency = mesh.face_adjacency
+
+    severities = []
+    for i in range(face_count):
+        neighbours = adjacency[np.any(adjacency == i, axis=1)].flatten()
+        neighbours = neighbours[neighbours != i]
+        if len(neighbours) == 0:
+            severity = 0.0
+        else:
+            neighbour_normals = normals[neighbours]
+            dots = np.clip(neighbour_normals @ normals[i], -1.0, 1.0)
+            angles = np.degrees(np.arccos(dots))
+            severity = float(np.max(angles))
+        severities.append({"face_index": int(i), "severity": severity})
+
+    return severities


### PR DESCRIPTION
## Summary
- create `heatmap.py` with `generate_heatmap` for STL face analysis
- call heatmap generation in `analyze_dfm_endpoint`
- expose heatmap data in returned JSON

## Testing
- `pytest -q`
- `python -m py_compile heatmap.py app.py`
- manual run of `generate_heatmap` on a sample STL

------
https://chatgpt.com/codex/tasks/task_e_6881db8079a883338997ac2f3834cdb8