### PR TITLE
Update Celery config and docs

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,7 +50,7 @@ app.config['SESSION_COOKIE_SECURE'] = True
 app.config['SESSION_COOKIE_SAMESITE'] = 'Lax'
 app.config['MAX_CONTENT_LENGTH'] = 100 * 1024 * 1024  # 100MB max file size
 # Execute Celery tasks synchronously when no worker is running
-app.config['CELERY_TASK_ALWAYS_EAGER'] = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'True').lower() == 'true'
+app.config['CELERY_TASK_ALWAYS_EAGER'] = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'False').lower() == 'true'
 
 # Database configuration
 database_url = os.environ.get("DATABASE_URL")

--- a/replit.md
+++ b/replit.md
@@ -88,9 +88,11 @@ CADlytitcs est une application SaaS basée sur Flask qui permet aux utilisateurs
 - **Platform**: Replit with Nix package management
 
 ### Configuration
-- Environment-based secret key management
-- Configurable upload limits and directories
-- CORS enabled for API flexibility
+- Gestion des clés secrètes par variables d'environnement
+- Limites de téléchargement et dossiers configurables
+- CORS activé pour plus de flexibilité API
+- Lancer un worker Celery avec la même valeur `CELERY_BROKER_URL` (Redis) pour
+  traiter les tâches en arrière-plan
 
 ## Changelog
 


### PR DESCRIPTION
## Summary
- change default CELERY_TASK_ALWAYS_EAGER flag
- document Celery worker launch with matching Redis configuration

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68820fe6e06083338883e439085b3272