### PR TITLE
Fix gunicorn timeout

### DIFF
--- a/procfile
+++ b/procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --timeout 600

--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,6 @@ services:
   name: cadlytics
   env: python
   buildCommand: "pip install -r requirements.txt"
-  startCommand: "gunicorn app:app"
+  startCommand: "gunicorn app:app --timeout 600"
   pythonVersion: 3.10
   plan: free


### PR DESCRIPTION
## Summary
- set gunicorn timeout to 600s in Procfile
- update `render.yaml` to match

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688215d1195483338b656e9a85a33c45