### PR TITLE
Gestion erreur 502 dans viewer

### DIFF
--- a/static/js/viewer.js
+++ b/static/js/viewer.js
@@ -589,6 +589,8 @@ class STEPViewer {
                     throw new Error('Le fichier est trop volumineux (max 100 Mo)');
                 } else if (response.status === 504) {
                     throw new Error('La conversion prend trop de temps. Essayez avec un fichier plus simple.');
+                } else if (response.status === 502) {
+                    throw new Error('Serveur indisponible (502). Veuillez réessayer plus tard.');
                 } else if (response.status === 403) {
                     // Try to get the error message from the response
                     const errorData = await response.json().catch(() => null);


### PR DESCRIPTION
## Résumé
- ajoute une vérification du `status` HTTP 502 dans `handleUpload`
- affiche un message clair "Serveur indisponible (502). Veuillez réessayer plus tard."

## Test
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_688216f100e883339b39a2ffb8839e7b