### PR TITLE
Configure Celery worker and Redis in docs

### DIFF
--- a/procfile
+++ b/procfile
@@ -1,1 +1,2 @@
 web: gunicorn app:app --timeout 600
+worker: ./start_worker.sh

--- a/replit.md
+++ b/replit.md
@@ -91,8 +91,18 @@ CADlytitcs est une application SaaS basée sur Flask qui permet aux utilisateurs
 - Gestion des clés secrètes par variables d'environnement
 - Limites de téléchargement et dossiers configurables
 - CORS activé pour plus de flexibilité API
-- Lancer un worker Celery avec la même valeur `CELERY_BROKER_URL` (Redis) pour
-  traiter les tâches en arrière-plan
+- Démarrer Redis puis le worker Celery avec la même variable `CELERY_BROKER_URL`
+  que le processus web :
+
+```bash
+redis-server --daemonize yes
+CELERY_BROKER_URL=redis://localhost:6379/0 ./start_worker.sh
+```
+- Lancer Gunicorn en utilisant la même variable :
+
+```bash
+CELERY_BROKER_URL=redis://localhost:6379/0 gunicorn app:app --timeout 600
+```
 - Pour Nginx, ajouter `client_max_body_size 100M;` et `proxy_read_timeout 600;`
 
 ## Changelog

--- a/start_worker.sh
+++ b/start_worker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Script de lancement du worker Celery pour Cadlytics
+export CELERY_BROKER_URL="${CELERY_BROKER_URL:-redis://localhost:6379/0}"
+exec celery -A app.celery worker --loglevel=info


### PR DESCRIPTION
## Summary
- document how to launch Redis and Celery with consistent broker URL
- add helper script to start the Celery worker
- reference the worker in `procfile`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68821e0a7ef883338d575ac57b97bd05