### PR TITLE
Intégration préliminaire du viewer xeokit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 analytics.json
+__pycache__/
+*.pyc
+test_env/

--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -1,0 +1,81 @@
+class XeokitViewerApp {
+    constructor() {
+        if (!this._isWebGL2()) {
+            console.warn('WebGL2 non disponible, chargement du viewer Three.js en secours');
+            const fallbackScript = document.createElement('script');
+            fallbackScript.src = '/static/js/viewer.js';
+            document.body.appendChild(fallbackScript);
+            return;
+        }
+
+        this.viewer = new xeokit.Viewer({
+            canvasId: 'viewer3d',
+            transparent: true
+        });
+
+        this._section = new xeokit.SectionPlanesPlugin(this.viewer);
+        this._measure = new xeokit.MeasurementsPlugin(this.viewer);
+        this._annotations = new xeokit.AnnotationPlugin(this.viewer);
+
+        this._bindUI();
+    }
+
+    _isWebGL2() {
+        const canvas = document.createElement('canvas');
+        return !!(window.WebGL2RenderingContext && canvas.getContext('webgl2'));
+    }
+
+    loadModel(url) {
+        const loader = new xeokit.XKTLoaderPlugin(this.viewer);
+        loader.load({ src: url, edges: true });
+    }
+
+    toggleWireframe() {
+        const state = !this._wireframe;
+        this._wireframe = state;
+        const objects = this.viewer.scene.objects;
+        for (const id in objects) {
+            objects[id].wireframe = state;
+        }
+    }
+
+    enableSection(axis) {
+        this._section.removeSectionPlanes();
+        const dir = axis === 'x' ? [1, 0, 0] : axis === 'y' ? [0, 1, 0] : [0, 0, 1];
+        this._section.createSectionPlane({ id: 'cut', dir, pos: [0, 0, 0] });
+    }
+
+    toggleMeasurements() {
+        this._measure.active = !this._measure.active;
+    }
+
+    applyHeatmap(data) {
+        for (const [id, color] of Object.entries(data)) {
+            const obj = this.viewer.scene.objects[id];
+            if (obj) obj.colorize = color;
+        }
+    }
+
+    exportPDF() {
+        const { jsPDF } = window.jspdf;
+        const doc = new jsPDF();
+        const img = this.viewer.canvas.toDataURL('image/png');
+        doc.text('Rapport DFM', 10, 10);
+        doc.addImage(img, 'PNG', 10, 20, 180, 120);
+        fetch('/api/dfm-summary').then(r => r.json()).then(data => {
+            doc.text(data.summary || '', 10, 150);
+            doc.save('rapport.pdf');
+        });
+    }
+
+    _bindUI() {
+        document.getElementById('toggleWireframeBtn')?.addEventListener('click', () => this.toggleWireframe());
+        document.getElementById('crossSectionBtn')?.addEventListener('click', () => this.enableSection('z'));
+        document.getElementById('measureBtn')?.addEventListener('click', () => this.toggleMeasurements());
+        document.getElementById('generatePdfBtn')?.addEventListener('click', () => this.exportPDF());
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    window.xeokitApp = new XeokitViewerApp();
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,10 +11,9 @@
     <!-- Custom CSS -->
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
     
-    <!-- Three.js and STL Loader -->
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/loaders/STLLoader.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/three@0.128.0/examples/js/controls/OrbitControls.js"></script>
+    <!-- xeokit SDK -->
+    <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
@@ -686,7 +685,7 @@
                   });
                 </script>
             <!-- Tes scripts JS d'abord -->
-            <script src="{{ url_for('static', filename='js/viewer.js') }}"></script>
+            <script src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
             <script src="{{ url_for('static', filename='js/design-insights.js') }}"></script>
 
             

--- a/xkt_converter.py
+++ b/xkt_converter.py
@@ -1,0 +1,27 @@
+"""Outil simple pour convertir un fichier STEP en XKT via xeokit-convert.
+
+Ce script requiert l'installation de xeokit-convert (npm).
+Exemple d'utilisation :
+    python xkt_converter.py input.step output.xkt
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def convert_step_to_xkt(step_path: str, xkt_path: str) -> None:
+    step = Path(step_path)
+    out = Path(xkt_path)
+    if not step.exists():
+        raise FileNotFoundError(step)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    cmd = ["npx", "@xeokit/xeokit-convert", str(step), "-o", str(out)]
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print("Usage: python xkt_converter.py input.step output.xkt")
+        sys.exit(1)
+    convert_step_to_xkt(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
## Résumé
- remplacement des imports Three.js dans `index.html` par xeokit
- ajout d'un viewer `xeokit_viewer.js` avec fallback vers Three.js
- exemple de script `xkt_converter.py` pour convertir un STEP en XKT
- mise à jour du `.gitignore`

## Tests
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68823cd116b883338e4f9b7a9d3c155b