### PR TITLE
Fix xeokit viewer fallback

### DIFF
--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -1,5 +1,12 @@
 class XeokitViewerApp {
     constructor() {
+        if (typeof window.xeokit === 'undefined') {
+            console.error('xeokit SDK non chargé, bascule vers viewer.js');
+            const fallbackScript = document.createElement('script');
+            fallbackScript.src = '/static/js/viewer.js';
+            document.body.appendChild(fallbackScript);
+            return;
+        }
         if (!this._isWebGL2()) {
             console.warn('WebGL2 non disponible, chargement du viewer Three.js en secours');
             const fallbackScript = document.createElement('script');

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
     
     <!-- xeokit SDK -->
-    <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <!-- Bootstrap Icons -->


### PR DESCRIPTION
## Summary
- defer load of xeokit SDK
- ensure fallback to viewer.js when xeokit isn't loaded

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node verify_scripts.js`
- `node test_xeokit_viewer.js`

------
https://chatgpt.com/codex/tasks/task_e_6882437f55388333a2586bfffb51f442