### PR TITLE
Secure OAuth debug script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ analytics.json
 __pycache__/
 *.pyc
 test_env/
+debug_redirect_uri.py

--- a/debug_redirect_uri.py
+++ b/debug_redirect_uri.py
@@ -2,16 +2,16 @@ import os
 from flask import Flask
 from flask_dance.contrib.google import make_google_blueprint
 
-# Simule l'environnement
-os.environ["GOOGLE_OAUTH_CLIENT_ID"] = "1089845484563-e76fjph8rr39t33o47v8p5t76erlmt36.apps.googleusercontent.com"
-os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = "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"
+# Les identifiants doivent être fournis via les variables d'environnement
+client_id = os.environ.get("GOOGLE_OAUTH_CLIENT_ID")
+client_secret = os.environ.get("GOOGLE_OAUTH_CLIENT_SECRET")
 
 app = Flask(__name__)
 app.config["SERVER_NAME"] = "cadlytitcs.com"
 
 google_bp = make_google_blueprint(
-    client_id="test",
-    client_secret="test",
+    client_id=client_id,
+    client_secret=client_secret,
     scope=["profile", "email"],  # <-- Virgule ici
     redirect_url="https://cadlytitcs.com/google_login/authorized"
 )


### PR DESCRIPTION
## Summary
- sanitize `debug_redirect_uri.py` by removing hard‑coded credentials and loading them from the environment
- ignore `debug_redirect_uri.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68832bb887f88333a03c4cb99d274f39