### PR TITLE
Change secret fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,8 @@ CELERY_BROKER_URL=redis://localhost:6379/0 ./start_worker.sh
 CELERY_BROKER_URL=redis://localhost:6379/0 ./start_beat.sh
 CELERY_BROKER_URL=redis://localhost:6379/0 gunicorn app:app --timeout 600
 ```
+
+## Variables d'environnement importantes
+
+- `SESSION_SECRET` : clé secrète pour chiffrer les sessions Flask. Obligation
+  de définir une valeur aléatoire en production.

--- a/app.py
+++ b/app.py
@@ -24,7 +24,10 @@ load_dotenv()
 
 # Create Flask app once
 app = Flask(__name__)
-app.secret_key = os.environ.get("SESSION_SECRET", os.getenv("SECRET_KEY", "dev"))
+secret = os.environ.get("SESSION_SECRET") or os.getenv("SECRET_KEY")
+if not secret:
+    raise RuntimeError("SESSION_SECRET environment variable is required")
+app.secret_key = secret
 
 app.config["SESSION_COOKIE_SECURE"] = True
 app.config["SESSION_COOKIE_SAMESITE"] = "Lax"


### PR DESCRIPTION
## Summary
- remove the default `'dev'` fallback for `SESSION_SECRET`
- note `SESSION_SECRET` in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68832c5fc4c08333984f38e7d5e6833a