### PR TITLE
Fix xeokit CDN version

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
     
     <!-- xeokit SDK -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
+    <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <!-- Bootstrap Icons -->


### PR DESCRIPTION
## Summary
- lock xeokit viewer to version 1.6.2 CDN URL

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68832d4b36708333b692a9169f61aaed