### PR TITLE
Remove viewer.js fallback

### DIFF
--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -1,17 +1,11 @@
 class XeokitViewerApp {
     constructor() {
         if (typeof window.xeokit === 'undefined') {
-            console.error('xeokit SDK non chargé, bascule vers viewer.js');
-            const fallbackScript = document.createElement('script');
-            fallbackScript.src = '/static/js/viewer.js';
-            document.body.appendChild(fallbackScript);
+            console.error('xeokit SDK non chargé, le viewer ne peut pas démarrer.');
             return;
         }
         if (!this._isWebGL2()) {
-            console.warn('WebGL2 non disponible, chargement du viewer Three.js en secours');
-            const fallbackScript = document.createElement('script');
-            fallbackScript.src = '/static/js/viewer.js';
-            document.body.appendChild(fallbackScript);
+            console.warn('WebGL2 non disponible, le viewer ne peut pas démarrer.');
             return;
         }
 


### PR DESCRIPTION
## Summary
- handle missing xeokit or WebGL2 by logging an error or warning

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68833526614c83339d20a376f6400b01