### PR TITLE
Intégration screenshot PDF

### DIFF
--- a/app.py
+++ b/app.py
@@ -668,6 +668,7 @@ def generate_pdf_report(conversion_id):
         
         # Use existing DFM data from database instead of re-analyzing (to avoid timeout)
         request_data = request.get_json() or {}
+        screenshot_data = request_data.get('screenshot')
         
         # Create simplified DFM data from database values
         class SimplifiedDFMReport:
@@ -776,12 +777,13 @@ def generate_pdf_report(conversion_id):
         # Create PDF with user language
         generator = DFMReportGenerator(language=user_lang)
         generated_path = generator.generate_report(
-            dfm_data, 
-            step_path, 
-            pdf_path, 
+            dfm_data,
+            step_path,
+            pdf_path,
             conversion_job.original_filename,
             material_recommendations,
-            lang=user_lang
+            lang=user_lang,
+            screenshot_image=screenshot_data
         )
         
         logger.info(f"PDF report generated: {generated_path}")

--- a/pdf_generator.py
+++ b/pdf_generator.py
@@ -609,8 +609,9 @@ class DFMReportGenerator:
         import base64
         return base64.b64encode(svg_content.encode()).decode()
         
-    def generate_report(self, dfm_data: Dict[str, Any], step_file_path: str, 
-                       filename: str, original_filename: str, material_recommendations: List[Dict] = None, lang: str = 'fr') -> str:
+    def generate_report(self, dfm_data: Dict[str, Any], step_file_path: str,
+                       filename: str, original_filename: str, material_recommendations: List[Dict] = None,
+                       lang: str = 'fr', screenshot_image: str | None = None) -> str:
         """Generate complete DFM PDF report"""
         try:
             # Generate 3D views from STEP file
@@ -630,7 +631,7 @@ class DFMReportGenerator:
             story = []
             
             # Title page
-            story.extend(self._create_title_page(original_filename, dfm_data, lang))
+            story.extend(self._create_title_page(original_filename, dfm_data, lang, screenshot_image))
             story.append(PageBreak())
             
             # Executive summary
@@ -669,7 +670,8 @@ class DFMReportGenerator:
                 pass
             return filename
         
-    def _create_title_page(self, original_filename: str, dfm_data: Dict[str, Any], lang: str = 'fr') -> List:
+    def _create_title_page(self, original_filename: str, dfm_data: Dict[str, Any],
+                           lang: str = 'fr', screenshot_image: str | None = None) -> List:
         """Create title page"""
         content = []
         
@@ -749,7 +751,19 @@ class DFMReportGenerator:
         ]))
         
         content.append(stats_table)
-        
+
+        if screenshot_image:
+            try:
+                if screenshot_image.startswith('data:image'):
+                    screenshot_image = screenshot_image.split(',', 1)[1]
+                img_data = base64.b64decode(screenshot_image)
+                from io import BytesIO
+                img_buffer = BytesIO(img_data)
+                content.append(Spacer(1, 20))
+                content.append(Image(img_buffer, width=160, height=120))
+            except Exception as e:
+                print(f"Failed to embed screenshot: {e}")
+
         return content
         
     def _create_executive_summary(self, dfm_data: Dict[str, Any]) -> List:

--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -105,16 +105,27 @@ class XeokitViewerApp {
         }
     }
 
+    captureScreenshot() {
+        return this.viewer.canvas.toDataURL('image/png');
+    }
+
     exportPDF() {
-        const { jsPDF } = window.jspdf;
-        const doc = new jsPDF();
-        const img = this.viewer.canvas.toDataURL('image/png');
-        doc.text('Rapport DFM', 10, 10);
-        doc.addImage(img, 'PNG', 10, 20, 180, 120);
-        fetch('/api/dfm-summary').then(r => r.json()).then(data => {
-            doc.text(data.summary || '', 10, 150);
-            doc.save('rapport.pdf');
-        });
+        const screenshot = this.captureScreenshot();
+        const convId = window.currentConversionId || '';
+        fetch(`/api/generate-pdf/${convId}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ screenshot })
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.success && data.pdf_filename) {
+                window.location.href = `/download-pdf/${data.pdf_filename}`;
+            } else {
+                console.error('Erreur génération PDF', data);
+            }
+        })
+        .catch(err => console.error('PDF request failed', err));
     }
 
     resetView() {


### PR DESCRIPTION
## Résumé
- ajout d'une méthode `captureScreenshot` dans le viewer Xeokit
- envoi du screenshot au backend lors de `exportPDF`
- prise en compte de l'image dans `generate_pdf_report`
- insertion de la capture sur la page de titre du PDF

## Tests
- `python -m py_compile pdf_generator.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68833a0d22948333bd4c701ccc193fe5