### PR TITLE
Fix xeokit SDK loading order

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
     
     <!-- xeokit SDK -->
-    <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <!-- Bootstrap Icons -->
@@ -670,7 +670,7 @@
         </div>
     </footer>
             <!-- Tes scripts JS d'abord -->
-            <script src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
+            <script defer src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
             <script src="{{ url_for('static', filename='js/design-insights.js') }}"></script>
 
             


### PR DESCRIPTION
## Summary
- load the xeokit SDK without `defer`
- defer loading of `xeokit_viewer.js`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68834761e73c8333b7d3db0a42296e82