### PR TITLE
Ajout conversion XKT et support viewer

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,147 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/migrations
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the python>=3.9 or backports.zoneinfo library and tzdata library.
+# Any required deps can installed by adding `alembic[tz]` to the pip requirements
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from models import db, ConversionJob, UserSession, User, OAuth
 from dfm_analyzer import analyze_dfm, DFMReport
 from heatmap import generate_heatmap
 from material_recommender import recommend_materials_for_questionnaire
+import xkt_converter
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
 from log import log_action
@@ -111,10 +112,12 @@ def convert_step_to_stl(job_id):
 
     step_path = os.path.abspath(os.path.join(app.config['UPLOAD_FOLDER'], job.step_filename))
     stl_path = os.path.abspath(os.path.join(app.config['CONVERTED_FOLDER'], job.stl_filename))
+    xkt_path = os.path.abspath(os.path.join(app.config['CONVERTED_FOLDER'], job.xkt_filename))
 
     try:
         result = cq.importers.importStep(step_path)
         cq.exporters.export(result, stl_path, "STL", tolerance=job.tolerance)
+        xkt_converter.convert_step_to_xkt(step_path, xkt_path)
         job.stl_file_size = os.path.getsize(stl_path)
         job.status = 'completed'
         job.completed_at = datetime.utcnow()
@@ -296,6 +299,7 @@ def upload_file():
         original_filename = secure_filename(file.filename)
         step_filename = f"{file_id}_{original_filename}"
         stl_filename = f"{file_id}.stl"
+        xkt_filename = f"{file_id}.xkt"
         
         # Save uploaded file
         step_path = os.path.abspath(os.path.join(app.config['UPLOAD_FOLDER'], step_filename))
@@ -330,6 +334,7 @@ def upload_file():
             original_filename=original_filename,
             step_filename=step_filename,
             stl_filename=stl_filename,
+            xkt_filename=xkt_filename,
             tolerance=tolerance,
             step_file_size=step_size,
             status='queued'
@@ -372,6 +377,11 @@ def view_file(filename):
             return jsonify({'error': 'Fichier non trouvé'}), 404
         
         file_size = os.path.getsize(file_path)
+        mime = "application/octet-stream"
+        if filename.lower().endswith(".stl"):
+            mime = "application/octet-stream"
+        elif filename.lower().endswith(".xkt"):
+            mime = "application/octet-stream"
         
         # For large files (>5MB), use chunked streaming
         if file_size > 5 * 1024 * 1024:
@@ -394,7 +404,7 @@ def view_file(filename):
                             break
                         yield data
             
-            response = Response(generate(), mimetype='application/octet-stream')
+            response = Response(generate(), mimetype=mime)
             response.headers['Content-Length'] = str(file_size)
             response.headers['Content-Disposition'] = f'inline; filename={filename}'
             # Add cache and streaming headers
@@ -404,7 +414,7 @@ def view_file(filename):
         else:
             # For smaller files, use normal send_from_directory
             return send_from_directory(app.config['CONVERTED_FOLDER'], filename, 
-                                     mimetype='application/octet-stream')
+                                     mimetype=mime)
     except Exception as e:
         logger.error(f"Error serving file {filename}: {str(e)}")
         return jsonify({'error': 'Erreur lors du chargement du fichier'}), 500
@@ -419,6 +429,7 @@ def job_status(job_id):
     data = {
         'status': job.status,
         'stl_filename': job.stl_filename if job.status == 'completed' else None,
+        'xkt_filename': job.xkt_filename if job.status == 'completed' else None,
         'stl_size': job.stl_file_size,
         'error': job.error_message
     }
@@ -429,6 +440,12 @@ def view_stl_job(job_id):
     """Télécharge le STL généré pour un job"""
     job = ConversionJob.query.get_or_404(job_id)
     return view_file(job.stl_filename)
+
+@app.route('/view/<job_id>.xkt')
+def view_xkt_job(job_id):
+    """Télécharge le XKT généré pour un job"""
+    job = ConversionJob.query.get_or_404(job_id)
+    return view_file(job.xkt_filename)
 
 @app.route('/api/conversions')
 def get_conversions():

--- a/migrations/README
+++ b/migrations/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/migrations/env.py
+++ b/migrations/env.py
@@ -1,0 +1,85 @@
+from logging.config import fileConfig
+
+from sqlalchemy import engine_from_config
+from sqlalchemy import pool
+import os
+
+from alembic import context
+from models import db
+
+# this is the Alembic Config object, which provides
+# access to the values within the .ini file in use.
+config = context.config
+
+# Interpret the config file for Python logging.
+# This line sets up loggers basically.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+# add your model's MetaData object here
+# for 'autogenerate' support
+# from myapp import mymodel
+# target_metadata = mymodel.Base.metadata
+config.set_main_option(
+    "sqlalchemy.url",
+    os.getenv("DATABASE_URL", "")
+)
+
+target_metadata = db.metadata
+
+# other values from the config, defined by the needs of env.py,
+# can be acquired:
+# my_important_option = config.get_main_option("my_important_option")
+# ... etc.
+
+
+def run_migrations_offline() -> None:
+    """Run migrations in 'offline' mode.
+
+    This configures the context with just a URL
+    and not an Engine, though an Engine is acceptable
+    here as well.  By skipping the Engine creation
+    we don't even need a DBAPI to be available.
+
+    Calls to context.execute() here emit the given string to the
+    script output.
+
+    """
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Run migrations in 'online' mode.
+
+    In this scenario we need to create an Engine
+    and associate a connection with the context.
+
+    """
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection, target_metadata=target_metadata
+        )
+
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/migrations/script.py.mako
+++ b/migrations/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/migrations/versions/1197ac9c0998_add_xkt_filename.py
+++ b/migrations/versions/1197ac9c0998_add_xkt_filename.py
@@ -1,0 +1,28 @@
+"""add xkt_filename
+
+Revision ID: 1197ac9c0998
+Revises: 
+Create Date: 2025-07-25 09:32:51.214509
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '1197ac9c0998'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema by adding xkt_filename column."""
+    op.add_column('conversion_jobs', sa.Column('xkt_filename', sa.String(length=255), nullable=True))
+
+
+def downgrade() -> None:
+    """Remove xkt_filename column."""
+    op.drop_column('conversion_jobs', 'xkt_filename')

--- a/models.py
+++ b/models.py
@@ -19,6 +19,7 @@ class ConversionJob(db.Model):
     original_filename = db.Column(db.String(255), nullable=False)
     step_filename = db.Column(db.String(255), nullable=False)
     stl_filename = db.Column(db.String(255), nullable=False)
+    xkt_filename = db.Column(db.String(255), nullable=True)
     tolerance = db.Column(db.Float, nullable=False, default=0.1)
     step_file_size = db.Column(db.Integer, nullable=False)
     stl_file_size = db.Column(db.Integer, nullable=True)
@@ -48,6 +49,7 @@ class ConversionJob(db.Model):
             'original_filename': self.original_filename,
             'step_filename': self.step_filename,
             'stl_filename': self.stl_filename,
+            'xkt_filename': self.xkt_filename,
             'tolerance': self.tolerance,
             'step_file_size': self.step_file_size,
             'stl_file_size': self.stl_file_size,

--- a/templates/index.html
+++ b/templates/index.html
@@ -679,6 +679,12 @@
                                     const tooltips = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
                                     tooltips.forEach(el => new bootstrap.Tooltip(el));
                                   });
+
+                                  function onConversionFinished(jobId) {
+                                    if (window.xeokitApp) {
+                                      xeokitApp.loadModel('/view/' + jobId + '.xkt');
+                                    }
+                                  }
                                 </script>
 </body>
 </html>


### PR DESCRIPTION
## Résumé
- génération d'un fichier XKT lors de la tâche Celery
- stockage du nom de fichier XKT en base et exposition via l'API
- nouvelle route pour servir les XKT
- ajout d'un script front pour charger le modèle XKT
- mise en place d'Alembic avec migration `add_xkt_filename`

## Tests
- `python -m compileall -q .`

------
https://chatgpt.com/codex/tasks/task_e_68834d712c588333b48fa63423752ffc