### PR TITLE
Fix xeokit SDK loading

### DIFF
--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -202,6 +202,16 @@ class XeokitViewerApp {
     }
 }
 
+function initXeokitViewer() {
+    if (typeof xeokit === 'object') {
+        window.xeokitApp = new XeokitViewerApp();
+    } else {
+        console.error('xeokit SDK non chargé, le viewer ne peut pas démarrer.');
+    }
+}
+
 document.addEventListener('DOMContentLoaded', () => {
-    window.xeokitApp = new XeokitViewerApp();
+    if (typeof xeokit !== 'undefined') {
+        initXeokitViewer();
+    }
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,8 +11,6 @@
     <!-- Custom CSS -->
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
     
-    <!-- xeokit SDK -->
-    <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
     
     <!-- Bootstrap Icons -->
@@ -669,6 +667,18 @@
             </div>
         </div>
     </footer>
+            <script>
+                const xeokitScript = document.createElement('script');
+                xeokitScript.src = "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js";
+                xeokitScript.onload = () => {
+                    console.log("\u2705 xeokit SDK charg\u00e9 !");
+                    if (typeof initXeokitViewer === 'function') {
+                        initXeokitViewer();
+                    }
+                };
+                xeokitScript.onerror = () => console.error("\u274c Impossible de charger xeokit SDK");
+                document.head.appendChild(xeokitScript);
+            </script>
             <!-- Tes scripts JS d'abord -->
             <script defer src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
             <script defer src="{{ url_for('static', filename='js/upload-handler.js') }}"></script>


### PR DESCRIPTION
## Summary
- dynamically load xeokit SDK in HTML
- defer viewer init until xeokit is available

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68837130f7508333a294d8cf138b55e5