### PR TITLE
Fix xeokit load sequence

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -667,18 +667,7 @@
             </div>
         </div>
     </footer>
-            <script>
-                const xeokitScript = document.createElement('script');
-                xeokitScript.src = "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js";
-                xeokitScript.onload = () => {
-                    console.log("\u2705 xeokit SDK charg\u00e9 !");
-                    if (typeof initXeokitViewer === 'function') {
-                        initXeokitViewer();
-                    }
-                };
-                xeokitScript.onerror = () => console.error("\u274c Impossible de charger xeokit SDK");
-                document.head.appendChild(xeokitScript);
-            </script>
+            <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
             <!-- Tes scripts JS d'abord -->
             <script defer src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
             <script defer src="{{ url_for('static', filename='js/upload-handler.js') }}"></script>


### PR DESCRIPTION
## Summary
- load Xeokit SDK directly with `defer` script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688373eb2394833388896ee4ed74fac8