### PR TITLE
Ajout onUploadSuccess dans le handler

### DIFF
--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -13,6 +13,14 @@ document.addEventListener('DOMContentLoaded', function () {
     const fileInput = document.getElementById('fileInput');
     const fileNameDisplay = document.getElementById('fileNameDisplay');
 
+    function onUploadSuccess(jobId) {
+        if (window.xeokitApp) {
+            xeokitApp.loadModel('/view/' + jobId + '.xkt');
+        }
+        if (viewerToolsPanel) viewerToolsPanel.style.display = 'block';
+        if (dfmControls) dfmControls.style.display = 'flex';
+    }
+
     if (fileInput) {
         fileInput.addEventListener('change', () => {
             if (fileNameDisplay) {
@@ -54,14 +62,11 @@ document.addEventListener('DOMContentLoaded', function () {
                         clearInterval(interval);
                         if (progressSection) progressSection.style.display = 'none';
                         if (uploadResults) uploadResults.style.display = 'block';
-                        const filename = info.xkt_filename || info.stl_filename;
-                        if (info.viewer_ready && window.xeokitApp && filename) {
-                            xeokitApp.loadModel('/view/' + filename);
-                            if (viewerToolsPanel) viewerToolsPanel.style.display = 'block';
-                        } else if (!info.viewer_ready) {
+                        if (info.viewer_ready) {
+                            onUploadSuccess(jobId);
+                        } else {
                             showError(info.viewer_error || 'Visualisation 3D impossible');
                         }
-                        if (dfmControls) dfmControls.style.display = 'flex';
                     } else if (info.status === 'failed') {
                         clearInterval(interval);
                         showError(info.error || 'Conversion échouée');

--- a/templates/index.html
+++ b/templates/index.html
@@ -673,18 +673,11 @@
             <script defer src="{{ url_for('static', filename='js/upload-handler.js') }}"></script>
             <script src="{{ url_for('static', filename='js/design-insights.js') }}"></script>
 
-            
                                 <script>
                                   document.addEventListener('DOMContentLoaded', function () {
                                     const tooltips = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
                                     tooltips.forEach(el => new bootstrap.Tooltip(el));
                                   });
-
-                                  function onConversionFinished(jobId) {
-                                    if (window.xeokitApp) {
-                                      xeokitApp.loadModel('/view/' + jobId + '.xkt');
-                                    }
-                                  }
                                 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- charge le modèle avec `onUploadSuccess` dans `upload-handler.js`
- simplifie `pollStatus` et active les contrôles du viewer depuis cette fonction
- supprime `onConversionFinished` devenu inutile dans `index.html`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68837e14d55483338c4b349de04f1176