### PR TITLE
Expose viewer globally

### DIFF
--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -14,8 +14,8 @@ document.addEventListener('DOMContentLoaded', function () {
     const fileNameDisplay = document.getElementById('fileNameDisplay');
 
     function onUploadSuccess(jobId) {
-        if (window.xeokitApp) {
-            xeokitApp.loadModel('/view/' + jobId + '.xkt');
+        if (window.viewer) {
+            window.viewer.loadModel('/view/' + jobId + '.xkt');
         }
         if (viewerToolsPanel) viewerToolsPanel.style.display = 'block';
         if (dfmControls) dfmControls.style.display = 'flex';

--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -202,9 +202,10 @@ class XeokitViewerApp {
     }
 }
 
-function initXeokitViewer() {
+function initViewer() {
     if (typeof xeokit === 'object') {
         window.xeokitApp = new XeokitViewerApp();
+        window.viewer = window.xeokitApp;
     } else {
         console.error('xeokit SDK non chargé, le viewer ne peut pas démarrer.');
     }
@@ -212,6 +213,6 @@ function initXeokitViewer() {
 
 document.addEventListener('DOMContentLoaded', () => {
     if (typeof xeokit !== 'undefined') {
-        initXeokitViewer();
+        initViewer();
     }
 });


### PR DESCRIPTION
## Summary
- instantiate `viewer` global alias for `xeokitApp`
- rename the init function to `initViewer`
- update `DOMContentLoaded` and uploader to use this new alias

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68873ed957ac83339b5b3c5a56f8f51b