### PR TITLE
Init viewer from upload handler

### DIFF
--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -1,6 +1,10 @@
 // Gestion de l'upload et du suivi de conversion
 
 document.addEventListener('DOMContentLoaded', function () {
+    if (typeof initViewer === 'function') {
+        initViewer();
+    }
+
     const form = document.getElementById('uploadForm');
     if (!form) return;
 


### PR DESCRIPTION
## Summary
- ensure viewer initialization by calling `initViewer()` inside `static/js/upload-handler.js`

## Testing
- `node -c static/js/upload-handler.js`


------
https://chatgpt.com/codex/tasks/task_e_68873fa6ee248333b6911c7efcc52d1f