### PR TITLE
Handle viewer init errors via global error handler

### DIFF
--- a/static/js/error-handler.js
+++ b/static/js/error-handler.js
@@ -1,0 +1,12 @@
+function showError(msg) {
+    const progressSection = document.getElementById('progressSection');
+    const errorAlert = document.getElementById('errorAlert');
+    const errorMessage = document.getElementById('errorMessage');
+
+    if (progressSection) progressSection.style.display = 'none';
+    if (errorMessage) errorMessage.textContent = msg;
+    if (errorAlert) errorAlert.style.display = 'block';
+}
+
+// Exposition globale au cas où ce fichier est inclus avec un module bundler
+window.showError = showError;

--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -108,9 +108,5 @@ document.addEventListener('DOMContentLoaded', function () {
         }
     }
 
-    function showError(msg) {
-        if (progressSection) progressSection.style.display = 'none';
-        if (errorMessage) errorMessage.textContent = msg;
-        if (errorAlert) errorAlert.style.display = 'block';
-    }
+    // La fonction showError est désormais définie globalement dans error-handler.js
 });

--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -2,10 +2,16 @@ class XeokitViewerApp {
     constructor() {
         if (typeof window.xeokit === 'undefined') {
             console.error('xeokit SDK non chargé, le viewer ne peut pas démarrer.');
+            if (typeof window.showError === 'function') {
+                window.showError('Visualiseur indisponible : SDK manquant.');
+            }
             return;
         }
         if (!this._isWebGL2()) {
             console.warn('WebGL2 non disponible, le viewer ne peut pas démarrer.');
+            if (typeof window.showError === 'function') {
+                window.showError('Visualiseur indisponible : WebGL2 non disponible.');
+            }
             return;
         }
 
@@ -208,6 +214,9 @@ function initViewer() {
         window.viewer = window.xeokitApp;
     } else {
         console.error('xeokit SDK non chargé, le viewer ne peut pas démarrer.');
+        if (typeof window.showError === 'function') {
+            window.showError('Visualiseur indisponible : SDK manquant.');
+        }
     }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -668,7 +668,8 @@
         </div>
     </footer>
             <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
-            <!-- Tes scripts JS d'abord -->
+            <!-- Scripts JS de l'application -->
+            <script defer src="{{ url_for('static', filename='js/error-handler.js') }}"></script>
             <script defer src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>
             <script defer src="{{ url_for('static', filename='js/upload-handler.js') }}"></script>
             <script src="{{ url_for('static', filename='js/design-insights.js') }}"></script>


### PR DESCRIPTION
## Summary
- factorize a global `showError` function
- use it when initializing the xeokit viewer
- include the new script before other frontend scripts
- adjust `upload-handler.js` to rely on the global function

## Testing
- `pytest -q`
- `ruff check .` *(fails: found 98 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688741888a3483339ffc91c0d8f6bf6a