### PR TITLE
Fix dynamic loading of xeokit SDK

### DIFF
--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -1,8 +1,10 @@
 // Gestion de l'upload et du suivi de conversion
 
 document.addEventListener('DOMContentLoaded', function () {
-    if (typeof initViewer === 'function') {
+    if (typeof initViewer === 'function' && typeof xeokit !== 'undefined') {
         initViewer();
+    } else {
+        console.log('Initialisation du viewer différée : SDK non disponible');
     }
 
     const form = document.getElementById('uploadForm');

--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -221,7 +221,22 @@ function initViewer() {
 }
 
 document.addEventListener('DOMContentLoaded', () => {
-    if (typeof xeokit !== 'undefined') {
+    if (typeof xeokit === 'undefined') {
+        console.log('xeokit SDK manquant, chargement dynamique...');
+        const script = document.createElement('script');
+        script.src = 'https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@latest/dist/xeokit-sdk.min.js';
+        script.onload = () => {
+            console.log('xeokit SDK chargé');
+            initViewer();
+        };
+        script.onerror = () => {
+            console.error('Échec du chargement du SDK xeokit');
+            if (typeof window.showError === 'function') {
+                window.showError('Visualiseur indisponible : SDK manquant.');
+            }
+        };
+        document.head.appendChild(script);
+    } else {
         initViewer();
     }
 });


### PR DESCRIPTION
## Summary
- avoid viewer init when xeokit isn't loaded
- dynamically fetch xeokit SDK if missing
- defer viewer init from upload handler until sdk is available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688744e2f8c0833396f2363d8aa50c0c