### PR TITLE
Fix Xeokit dynamic loading

### DIFF
--- a/static/js/xeokit_viewer.js
+++ b/static/js/xeokit_viewer.js
@@ -220,23 +220,32 @@ function initViewer() {
     }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
-    if (typeof xeokit === 'undefined') {
-        console.log('xeokit SDK manquant, chargement dynamique...');
-        const script = document.createElement('script');
-        script.src = 'https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@latest/dist/xeokit-sdk.min.js';
-        script.onload = () => {
-            console.log('xeokit SDK chargé');
-            initViewer();
-        };
-        script.onerror = () => {
-            console.error('Échec du chargement du SDK xeokit');
-            if (typeof window.showError === 'function') {
-                window.showError('Visualiseur indisponible : SDK manquant.');
-            }
-        };
-        document.head.appendChild(script);
-    } else {
-        initViewer();
+function loadXeokitSDK(callback) {
+    if (typeof window.xeokit !== 'undefined') {
+        console.log('SDK xeokit déjà présent');
+        callback();
+        return;
     }
+
+    console.log('Chargement du SDK xeokit...');
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/xeokit-sdk@1.5.2/dist/xeokit.min.js';
+
+    script.onload = () => {
+        console.log('SDK xeokit chargé');
+        callback();
+    };
+
+    script.onerror = () => {
+        console.error('Échec du chargement du SDK xeokit');
+        if (typeof window.showError === 'function') {
+            window.showError('Visualiseur indisponible : SDK manquant.');
+        }
+    };
+
+    document.head.appendChild(script);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    loadXeokitSDK(initViewer);
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -667,7 +667,7 @@
             </div>
         </div>
     </footer>
-            <script defer src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@1.6.2/dist/xeokit-sdk.min.js"></script>
+            <script defer src="https://cdn.jsdelivr.net/npm/xeokit-sdk@1.5.2/dist/xeokit.min.js"></script>
             <!-- Scripts JS de l'application -->
             <script defer src="{{ url_for('static', filename='js/error-handler.js') }}"></script>
             <script defer src="{{ url_for('static', filename='js/xeokit_viewer.js') }}"></script>


### PR DESCRIPTION
## Summary
- update the Xeokit CDN URL in HTML
- add a `loadXeokitSDK` helper and hook it to DOMContentLoaded

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688748f52a6c833380569ec17da3f204