### PR TITLE
Add viewer route and template

### DIFF
--- a/app.py
+++ b/app.py
@@ -580,6 +580,14 @@ def view_xkt_job(job_id):
     job = ConversionJob.query.get_or_404(job_id)
     return view_file(job.xkt_filename)
 
+
+@app.route('/viewer/<filename>')
+def viewer(filename):
+    """Affiche un modèle STL dans un template dédié"""
+    if '..' in filename or os.path.isabs(filename):
+        return jsonify({'error': 'Nom de fichier invalide'}), 400
+    return render_template('viewer.html', model_file=filename)
+
 @app.route('/api/conversions')
 def get_conversions():
     """Get list of conversion jobs - limited to 5 most recent for current user"""

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <title>Visualiseur 3D</title>
+    <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
+</head>
+<body>
+    <canvas id="myCanvas" style="width:100%; height:600px;"></canvas>
+    <canvas id="myOverviewCanvas" style="width:200px; height:150px;"></canvas>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `/viewer/<filename>` route to serve a simple 3D viewer page
- create `viewer.html` with two canvas elements and xeokit CDN script

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888b7efe9988333919763415c051357