### PR TITLE
Initialize xeokit viewer for STL models

### DIFF
--- a/static/js/init_xeokit.js
+++ b/static/js/init_xeokit.js
@@ -1,0 +1,53 @@
+function initXeokit(stlUrl) {
+    if (typeof Viewer !== 'function') {
+        console.error('xeokit SDK manquant');
+        return null;
+    }
+
+    const viewer = new Viewer({
+        canvasId: 'myCanvas'
+    });
+
+    const loader = new STLLoaderPlugin(viewer);
+
+    const section = new SectionPlanesPlugin(viewer, {
+        overviewCanvasId: 'myOverviewCanvas'
+    });
+
+    const distancePlugin = new DistanceMeasurementsPlugin(viewer);
+    const distanceControl = new DistanceMeasurementsMouseControl(viewer, {
+        measurements: distancePlugin
+    });
+
+    const annotations = new AnnotationsPlugin(viewer);
+
+    loader.load({
+        src: stlUrl,
+        edges: true,
+        success: () => {
+            const aabb = viewer.scene.getAABB();
+            viewer.cameraFlight.flyTo({ aabb });
+
+            const center = [
+                (aabb[0] + aabb[3]) / 2,
+                (aabb[1] + aabb[4]) / 2,
+                (aabb[2] + aabb[5]) / 2
+            ];
+
+            annotations.createAnnotation({
+                id: 'demo',
+                worldPos: center,
+                text: 'Annotation de démonstration'
+            });
+        }
+    });
+
+    return viewer;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const stlUrl = document.body.dataset.modelUrl;
+    if (stlUrl) {
+        window.viewer = initXeokit(stlUrl);
+    }
+});

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -5,8 +5,10 @@
     <title>Visualiseur 3D</title>
     <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
 </head>
-<body>
+<body data-model-url="{{ url_for('view_file', filename=model_file) }}">
     <canvas id="myCanvas" style="width:100%; height:600px;"></canvas>
     <canvas id="myOverviewCanvas" style="width:200px; height:150px;"></canvas>
+
+    <script src="{{ url_for('static', filename='js/init_xeokit.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a small script to start a xeokit `Viewer`
- load STL files and enable clipping, distances and annotations
- update `viewer.html` to use this new script and provide the STL URL

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6888bb8d0fbc8333a5cb1a6f85c86b03