### PR TITLE
Add OCP dependency for STEP conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Ce dépôt contient le code du MVP de Cadlytics, SaaS d'analyse DFM et de visual
 Le viewer 3D repose désormais sur **Xeokit** et rend les modèles au format **XKT**
 (conversion réalisée via `xkt_converter.py`).
 
+La conversion STEP vers STL s'appuie sur la librairie **OCP** (`pythonocc-core`).
+
 ## Nettoyage automatique des fichiers
 
 Les fichiers téléchargés (`uploads/`) et convertis (`converted/`) sont conservés pendant **7 jours** par défaut. La tâche Celery `cleanup_old_files` supprime quotidiennement les fichiers plus anciens.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "gunicorn>=23.0.0",
     "psycopg2-binary>=2.9.10",
     "cadquery>=2.5.2",
+    "OCP>=0.1.9",
     "werkzeug>=3.1.3",
     "flask-migrate>=4.1.0",
     "sqlalchemy>=2.0.41",

--- a/requirements.txt
+++ b/requirements.txt
@@ -69,6 +69,7 @@ Pillow==11.2.1
 cadquery==2.4.0
 casadi==3.7.0
 trimesh==4.6.13
+OCP==0.1.9
 
 # Mathematical/Scientific (required for CAD packages)
 numpy==1.24.4


### PR DESCRIPTION
## Summary
- add OCP in requirements and pyproject
- mention OCP requirement for STEP→STL in README

## Testing
- `pytest -q --ignore=test_env`

------
https://chatgpt.com/codex/tasks/task_e_6888becc9104833389676b090e988af8