### PR TITLE
Fix viewer init script

### DIFF
--- a/static/js/upload-handler.js
+++ b/static/js/upload-handler.js
@@ -11,8 +11,10 @@ document.addEventListener('DOMContentLoaded', function () {
     const initialModel = document.body.dataset.model;
     if (initialModel && window.viewer && typeof window.viewer.loadModel === 'function') {
         window.viewer.loadModel('/view/' + initialModel);
-        document.getElementById('viewerToolsPanel')?.style.display = 'block';
-        document.getElementById('dfmControls')?.style.display = 'flex';
+        const toolsEl = document.getElementById('viewerToolsPanel');
+        if (toolsEl) toolsEl.style.display = 'block';
+        const dfmEl = document.getElementById('dfmControls');
+        if (dfmEl) dfmEl.style.display = 'flex';
     }
 
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -670,7 +670,7 @@
             </div>
         </div>
     </footer>
-            <script defer src="{{ url_for('static', filename='js/xeokit.min.js') }}"></script>
+            <script type="module" src="{{ url_for('static', filename='js/xeokit.min.js') }}"></script>
             
             <!-- Scripts JS de l'application -->
             <script defer src="{{ url_for('static', filename='js/error-handler.js') }}"></script>


### PR DESCRIPTION
## Summary
- fix optional chaining LHS bug when initializing viewer tools
- load xeokit SDK as an ES module

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888cd3802188333a204da06a5d0e74a