### PR TITLE
Fix xeokit script tag

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -670,7 +670,7 @@
             </div>
         </div>
     </footer>
-            <script type="module" src="{{ url_for('static', filename='js/xeokit.min.js') }}"></script>
+            <script src="{{ url_for('static', filename='js/xeokit.min.js') }}"></script>
             
             <!-- Scripts JS de l'application -->
             <script defer src="{{ url_for('static', filename='js/error-handler.js') }}"></script>


### PR DESCRIPTION
## Summary
- remove `type="module"` attribute from xeokit script tag

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6888da281f5c83339b2f7f84b3cfbf63