### PR TITLE
Mise à jour build frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ Pour générer le bundle dans `static/dist/` :
 npm run build
 ```
 Ce script régénère `static/dist/main.js`, fichier ignoré par Git.
+Exécuter `npm run build` avant chaque déploiement ou lancement de l'application afin de garantir la présence de `static/dist/main.js`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "analyseur-step",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
         "jspdf": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "vite build"
+    "build": "vite build",
+    "postinstall": "npm run build"
   },
   "keywords": [],
   "author": "",

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
 - type: web
   name: cadlytics
   env: python
-  buildCommand: "pip install -r requirements.txt"
+  buildCommand: "npm install && npm run build && pip install -r requirements.txt"
   startCommand: "gunicorn app:app --timeout 600"
   pythonVersion: 3.10
   plan: free


### PR DESCRIPTION
## Résumé
- rappel d'exécuter `npm run build` avant chaque déploiement ou lancement
- exécution automatique du build Node via le script `postinstall`
- build exécuté dans `render.yaml`

## Tests
- `python -m py_compile $(git ls-files '*.py')`
- `npm install` (inclut `npm run build`)

------
https://chatgpt.com/codex/tasks/task_e_688b422504188333b3b04a7a5b0c4d95