### PR TITLE
Add dev build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,9 @@ Pour générer le bundle dans `static/dist/` :
 npm run build
 ```
 Ce script régénère `static/dist/main.js`.
-Exécuter `npm run build` après chaque modification du front pour mettre 
-à jour ce bundle avant de déployer ou lancer l'application.
+Pendant le développement il suffit de lancer
+
+```bash
+npm run dev
+```
+pour reconstruire automatiquement ce fichier à chaque modification.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "vite build",
+    "dev": "vite build --watch",
     "postinstall": "npm run build"
   },
   "keywords": [],

--- a/procfile
+++ b/procfile
@@ -1,3 +1,3 @@
-web: gunicorn app:app --timeout 600
+web: npm run build && gunicorn app:app --timeout 600
 worker: ./start_worker.sh
 beat: ./start_beat.sh


### PR DESCRIPTION
## Summary
- allow Vite rebuild on changes via `npm run dev`
- document the `dev` script in README
- run `npm run build` before starting Gunicorn

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b4e002b508333a42bb20fc8210ce5