### PR TITLE
Fix STL export settings

### DIFF
--- a/app.py
+++ b/app.py
@@ -172,7 +172,7 @@ def ocp_step_to_stl(step_path: str, stl_path: str) -> None:
     reader.TransferRoots()
     shape = reader.OneShape()
     writer = StlAPI_Writer()
-    Interface_Static.SetCVal("write.stl.ascii", "False")
+    Interface_Static.SetIVal_s("write.stl.mode", 0)
     writer.SetASCIIMode(False)
     writer.Write(shape, stl_path)
 


### PR DESCRIPTION
## Summary
- set OCP STL mode using `Interface_Static.SetIVal_s`

## Testing
- `pytest -q` *(fails: no tests found)*
- `pip install -r requirements.txt` *(fails: Invalid version 'x86_64')*
- `npx @xeokit/xeokit-convert --source sample.step -o /tmp/out.xkt` *(fails: unsupported source format)*

------
https://chatgpt.com/codex/tasks/task_e_688b65177a3c83338313db25c7e8cc0b