### PR TITLE
Autoriser les clics sur le label d'upload

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1394,7 +1394,11 @@ body {
     }
 
     .upload-content {
-      pointer-events: none; /* Permet au dragover de traverser */
+      pointer-events: auto; /* Autorise les clics sur le contenu */
+    }
+
+    .upload-content label[for="fileInput"] {
+      pointer-events: auto;
     }
 
     #fileNameDisplay {


### PR DESCRIPTION
## Summary
- Supprime `pointer-events: none` sur `.upload-content` afin de rendre le contenu cliquable.
- Ajoute une règle explicite pour que le `label` associé à `fileInput` accepte les événements de pointeur.

## Testing
- `python -m pytest`
- `npm test` *(échoue : no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68962258229883339eeaf20823840772