### PR TITLE
Installe xeokit-convert et gère les échecs de conversion

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ import uuid
 import time
 import shutil
 import tempfile
+import subprocess
 from OCP.STEPControl import STEPControl_Reader
 from OCP.StlAPI import StlAPI_Writer
 from OCP.Interface import Interface_Static
@@ -416,6 +417,23 @@ def convert_step():
 
     try:
         xkt_converter.convert_step_to_xkt(step_path, out_path)
+    except subprocess.CalledProcessError as e:
+        logger.exception(f"Conversion STEP->XKT échouée: {e}")
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        return (
+            jsonify(
+                {
+                    "success": False,
+                    "error": "xeokit-convert a échoué",
+                    "details": e.stderr,
+                }
+            ),
+            400,
+        )
+    except FileNotFoundError:
+        logger.exception("npx ou xeokit-convert introuvable")
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        return jsonify({'success': False, 'error': 'xeokit-convert non installé'}), 400
     except Exception as e:
         logger.exception(f"Conversion STEP->XKT échouée: {e}")
         shutil.rmtree(temp_dir, ignore_errors=True)

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,13 @@ services:
 - type: web
   name: cadlytics
   env: python
-  buildCommand: "npm install && npm run build && pip install -r requirements.txt"
+  buildCommand: |
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+    apt-get install -y nodejs
+    npm install -g @xeokit/xeokit-convert
+    npm install
+    npm run build
+    pip install -r requirements.txt
   startCommand: "gunicorn app:app --timeout 600"
   pythonVersion: 3.10
   plan: free

--- a/xkt_converter.py
+++ b/xkt_converter.py
@@ -16,8 +16,12 @@ def convert_step_to_xkt(step_path: str, xkt_path: str) -> None:
     if not step.exists():
         raise FileNotFoundError(step)
     out.parent.mkdir(parents=True, exist_ok=True)
-    cmd = ["npx", "@xeokit/xeokit-convert", str(step), "-o", str(out)]
-    subprocess.check_call(cmd)
+    cmd = ["npx", "@xeokit/xeokit-convert", "-s", str(step), "-o", str(out)]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        raise subprocess.CalledProcessError(
+            result.returncode, cmd, output=result.stdout, stderr=result.stderr
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Résumé
- installe Node et `@xeokit/xeokit-convert` durant le build pour l'environnement Render
- fiabilise `convert_step_to_xkt` en capturant la sortie de `xeokit-convert`
- retourne une réponse JSON claire quand la conversion échoue

## Tests
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689629d1000c83338263c5fe3e57bdd3