### PR TITLE
Configure Render build and start commands

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,13 +2,16 @@ services:
 - type: web
   name: cadlytics
   env: python
+  envVars:
+    - key: CONVERTED_FOLDER
+      value: /tmp/converted
   buildCommand: |
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
     apt-get install -y nodejs
-    npm ci
+    npm ci || npm install
     npm install -g @xeokit/xeokit-convert
     npm run build
     pip install -r requirements.txt
-  startCommand: "gunicorn app:app --timeout 600"
+  startCommand: "gunicorn app:app --workers=2 --timeout=180"
   pythonVersion: 3.10
   plan: free


### PR DESCRIPTION
## Summary
- add CONVERTED_FOLDER env var for Render deployment
- adjust build command to fallback to npm install
- run gunicorn with 2 workers and shorter timeout

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964a0521d083338bb11725e1e24bbe