### PR TITLE
Ajout timeout conversion et ajustement Gunicorn

### DIFF
--- a/app.py
+++ b/app.py
@@ -439,7 +439,9 @@ def convert_step():
             logger.info("xeokit-convert not found, using npx fallback")
         else:
             cmd = [XEOKIT_BIN, "--input", step_path, "--output", str(out_path)]
-        proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, check=False, timeout=150
+        )
         logger.info(
             "xeokit-convert rc=%s stdout=%s stderr=%s",
             proc.returncode,
@@ -460,6 +462,11 @@ def convert_step():
                 ),
                 400,
             )
+    except subprocess.TimeoutExpired:
+        duration = time.time() - start
+        logger.exception("xeokit-convert timeout après %.2fs", duration)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+        return jsonify({"success": False, "error": "convert_timeout"}), 504
     except FileNotFoundError:
         duration = time.time() - start
         logger.exception("xeokit-convert introuvable après %.2fs", duration)

--- a/render.yaml
+++ b/render.yaml
@@ -14,6 +14,6 @@ services:
     export PATH="/usr/local/bin:$PATH"
     echo ">>> PATH at start: $PATH"
     echo ">>> which xeokit-convert (start): $(which xeokit-convert)"
-    gunicorn app:app --workers=2 --timeout=180
+    gunicorn app:app --workers=2 --timeout=300
   pythonVersion: 3.10
   plan: free


### PR DESCRIPTION
## Résumé
- impose un délai de 150s sur `xeokit-convert` pour éviter les coupures Render
- augmente le `--timeout` Gunicorn à 300s

## Tests
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68965e0124ac8333ba6732b93c89670f