### PR TITLE
fix: ensure xeokit-convert uses system path

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -6,15 +6,15 @@ services:
     - key: CONVERTED_FOLDER
       value: /tmp/converted
     - key: XEOKIT_CONVERT
-      value: /root/.nvm/versions/node/v22.18.0/bin/xeokit-convert
+      value: /usr/local/bin/xeokit-convert
   buildCommand: |
     npm install -g @xeokit/xeokit-convert
-    echo ">>> npm bin -g: $(npm bin -g)"
+    ln -sf $(npm config get prefix | tail -n 1)/bin/xeokit-convert /usr/local/bin/xeokit-convert
+    echo ">>> npm prefix -g: $(npm config get prefix | tail -n 1)"
     echo ">>> which xeokit-convert (build): $(which xeokit-convert)"
     pip install -r requirements.txt
   startCommand: |
-    export PATH="/root/.nvm/versions/node/v22.18.0/bin:$PATH"
-    export PATH="/usr/local/bin:$PATH"
+    export PATH="/usr/local/bin:/root/.nvm/versions/node/v22.18.0/bin:$PATH"
     echo ">>> PATH at start: $PATH"
     echo ">>> which xeokit-convert (start): $(which xeokit-convert)"
     gunicorn app:app --workers=2 --timeout=300


### PR DESCRIPTION
## Summary
- ensure `XEOKIT_CONVERT` points to `/usr/local/bin/xeokit-convert`
- install `xeokit-convert` globally and symlink it into `/usr/local/bin` during build
- set PATH so runtime uses system xeokit binary

## Testing
- `export PATH="/usr/local/bin:/root/.nvm/versions/node/v22.18.0/bin:$PATH"; echo ">>> PATH at start: $PATH"; echo ">>> which xeokit-convert (start): $(which xeokit-convert)"`
- `pip install flask` *(fails: ModuleNotFoundError: No module named 'flask_cors')*
- `pip install -r requirements.txt` *(fails: Invalid version: 'x86_64')*


------
https://chatgpt.com/codex/tasks/task_e_68975a6869ec833391db8d228193df92