### PR TITLE
chore: bump jspdf to ^3.7.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vite": "^7.0.6"
   },
   "dependencies": {
-    "jspdf": "^3.0.1",
+    "jspdf": "^3.7.3",
     "@xeokit/xeokit-convert": "^1.3.0"
   }
 }


### PR DESCRIPTION
## Summary
- update jspdf dependency to ^3.7.3

## Testing
- `npm install` (fails: No matching version found for jspdf@^3.7.3)
- `npm test` (fails: Error: no test specified)
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6897a0ce90688333bddf9b52713e184c