### PR TITLE
Ajout file de tâches Celery pour conversion STEP

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from dfm_analyzer import analyze_dfm, DFMReport
 from heatmap import generate_heatmap
 from material_recommender import recommend_materials_for_questionnaire
 import xkt_converter
+from tasks.conversion import generate_preview, generate_final
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
 from log import log_action
@@ -280,55 +281,6 @@ def process_step_file(job_id, demolding_axis='z'):
     job.viewer_ready = viewer_ready
     job.viewer_error = viewer_error
 
-    db.session.commit()
-
-
-@celery.task()
-def task_generate_preview(job_id):
-    """Generate low resolution preview"""
-    job = ModelJob.query.get(job_id)
-    if not job:
-        return
-    advance_model_job_status(job, 'processing')
-    try:
-        preview_key = f"{job.id}/preview.glb"
-        preview_path = os.path.join(app.config['CONVERTED_FOLDER'], preview_key)
-        os.makedirs(os.path.dirname(preview_path), exist_ok=True)
-        with open(preview_path, 'wb') as fh:
-            fh.write(b'preview')
-        job.preview_url = preview_key
-        advance_model_job_status(job, 'preview_ready')
-    except Exception as exc:
-        job.error_message = str(exc)
-        advance_model_job_status(job, 'error')
-    db.session.commit()
-
-
-@celery.task()
-def task_generate_final(job_id):
-    """Generate final assets and DFM JSON"""
-    job = ModelJob.query.get(job_id)
-    if not job:
-        return
-    advance_model_job_status(job, 'processing')
-    try:
-        final_key = f"{job.id}/final.glb"
-        final_path = os.path.join(app.config['CONVERTED_FOLDER'], final_key)
-        os.makedirs(os.path.dirname(final_path), exist_ok=True)
-        with open(final_path, 'wb') as fh:
-            fh.write(b'final')
-        job.final_url = final_key
-        advance_model_job_status(job, 'final_ready')
-
-        dfm_key = f"{job.id}/dfm.json"
-        dfm_path = os.path.join(app.config['CONVERTED_FOLDER'], dfm_key)
-        with open(dfm_path, 'w') as fh:
-            json.dump({'status': 'ok'}, fh)
-        job.dfm_json_url = dfm_key
-        advance_model_job_status(job, 'dfm_ready')
-    except Exception as exc:
-        job.error_message = str(exc)
-        advance_model_job_status(job, 'error')
     db.session.commit()
 
 
@@ -710,8 +662,8 @@ def api_upload():
     final_path = os.path.join(app.config['UPLOAD_FOLDER'], f"{job.id}.step")
     os.rename(tmp_path, final_path)
 
-    task_generate_preview.delay(job.id)
-    task_generate_final.delay(job.id)
+    generate_preview.delay(job.id)
+    generate_final.delay(job.id)
 
     logger.info(json.dumps({'action': 'upload', 'result': 'queued', 'job_id': job.id}))
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.9'
+services:
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+  worker:
+    build: .
+    command: ./start_worker.sh
+    volumes:
+      - .:/app
+    environment:
+      - CELERY_BROKER_URL=redis://redis:6379/0
+    depends_on:
+      - redis

--- a/start_worker.sh
+++ b/start_worker.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 # Script de lancement du worker Celery pour Cadlytics
 export CELERY_BROKER_URL="${CELERY_BROKER_URL:-redis://localhost:6379/0}"
-exec celery -A app.celery worker --loglevel=info
+exec celery -A worker.celery worker --loglevel=info

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -1,0 +1,1 @@
+# Task package for Celery workers

--- a/tasks/conversion.py
+++ b/tasks/conversion.py
@@ -1,0 +1,120 @@
+import os
+import tempfile
+import shutil
+import logging
+
+import boto3
+import cadquery as cq
+import trimesh
+from flask import current_app
+
+from models import db, ModelJob, advance_model_job_status
+from worker import celery
+from tasks.dfm import run_dfm
+
+logger = logging.getLogger(__name__)
+S3_CLIENT = boto3.client("s3")
+MAX_RETRIES = 3
+PREVIEW_MAX_FACES = 300_000
+PREVIEW_RATIO = 0.5
+
+
+def _upload_to_s3(local_path: str, key: str) -> str:
+    """Upload a file to S3 and return the key."""
+    bucket = current_app.config.get("S3_BUCKET") or os.getenv("S3_BUCKET")
+    if not bucket:
+        raise RuntimeError("S3_BUCKET not configured")
+    S3_CLIENT.upload_file(local_path, bucket, key)
+    return key
+
+
+def _notify_status(job: ModelJob) -> None:
+    url = os.getenv("MODEL_STATUS_WEBHOOK")
+    if url:
+        try:
+            import requests
+            requests.post(url, json={"id": job.id, "status": job.status})
+        except Exception:
+            logger.exception("status webhook failed")
+
+
+@celery.task(bind=True, max_retries=MAX_RETRIES, name="tasks.generate_preview")
+def generate_preview(self, job_id: str) -> None:
+    """Convert STEP to decimated preview GLB."""
+    job = ModelJob.query.get(job_id)
+    if not job:
+        return
+    advance_model_job_status(job, "processing")
+    db.session.commit()
+    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{job.id}.step")
+    tmp_dir = tempfile.mkdtemp(prefix="preview_")
+    try:
+        shape = cq.importers.importStep(step_path)
+        vertices, faces = shape.val().tessellate(1.0)
+        mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+        target = int(min(PREVIEW_MAX_FACES, len(mesh.faces) * PREVIEW_RATIO))
+        if len(mesh.faces) > target:
+            mesh = mesh.simplify_quadratic_decimation(target)
+        out_path = os.path.join(tmp_dir, "preview.glb")
+        mesh.export(out_path, file_type="glb")
+        key = f"models/{job.sha256}/preview.glb"
+        _upload_to_s3(out_path, key)
+        job.preview_url = key
+        advance_model_job_status(job, "preview_ready")
+        db.session.commit()
+        _notify_status(job)
+    except Exception as exc:
+        db.session.rollback()
+        if self.request.retries >= self.max_retries:
+            job.error_message = str(exc)
+            advance_model_job_status(job, "error")
+            db.session.commit()
+            _notify_status(job)
+            raise
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+@celery.task(bind=True, max_retries=MAX_RETRIES, name="tasks.generate_final")
+def generate_final(self, job_id: str) -> None:
+    """Generate final asset (GLB or XKT) and enqueue DFM."""
+    job = ModelJob.query.get(job_id)
+    if not job:
+        return
+    advance_model_job_status(job, "processing")
+    db.session.commit()
+    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{job.id}.step")
+    tmp_dir = tempfile.mkdtemp(prefix="final_")
+    try:
+        shape = cq.importers.importStep(step_path)
+        solids = shape.solids().toList() if hasattr(shape, "solids") else []
+        if len(solids) > 1:
+            # Assemblage -> XKT via xeokit-convert CLI
+            from xkt_converter import convert_step_to_xkt
+            out_path = os.path.join(tmp_dir, "final.xkt")
+            convert_step_to_xkt(step_path, out_path)
+            key = f"models/{job.sha256}/final.xkt"
+        else:
+            vertices, faces = shape.val().tessellate(0.2)
+            mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+            out_path = os.path.join(tmp_dir, "final.glb")
+            mesh.export(out_path, file_type="glb")
+            key = f"models/{job.sha256}/final.glb"
+        _upload_to_s3(out_path, key)
+        job.final_url = key
+        advance_model_job_status(job, "final_ready")
+        db.session.commit()
+        _notify_status(job)
+        run_dfm.delay(job_id)
+    except Exception as exc:
+        db.session.rollback()
+        if self.request.retries >= self.max_retries:
+            job.error_message = str(exc)
+            advance_model_job_status(job, "error")
+            db.session.commit()
+            _notify_status(job)
+            raise
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -1,0 +1,77 @@
+import os
+import json
+import tempfile
+import shutil
+import logging
+import dataclasses
+
+import boto3
+import cadquery as cq
+import trimesh
+from flask import current_app
+
+from models import db, ModelJob, advance_model_job_status
+from worker import celery
+from dfm_analyzer import analyze_dfm
+from heatmap import generate_heatmap
+
+logger = logging.getLogger(__name__)
+S3_CLIENT = boto3.client("s3")
+MAX_RETRIES = 3
+
+
+def _upload_to_s3(local_path: str, key: str) -> str:
+    bucket = current_app.config.get("S3_BUCKET") or os.getenv("S3_BUCKET")
+    if not bucket:
+        raise RuntimeError("S3_BUCKET not configured")
+    S3_CLIENT.upload_file(local_path, bucket, key)
+    return key
+
+
+def _notify_status(job: ModelJob) -> None:
+    url = os.getenv("MODEL_STATUS_WEBHOOK")
+    if url:
+        try:
+            import requests
+            requests.post(url, json={"id": job.id, "status": job.status})
+        except Exception:
+            logger.exception("status webhook failed")
+
+
+@celery.task(bind=True, max_retries=MAX_RETRIES, name="tasks.run_dfm")
+def run_dfm(self, job_id: str) -> None:
+    """Analyze STEP and upload DFM report with heatmap."""
+    job = ModelJob.query.get(job_id)
+    if not job:
+        return
+    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{job.id}.step")
+    tmp_dir = tempfile.mkdtemp(prefix="dfm_")
+    try:
+        report = analyze_dfm(step_path)
+        report_dict = dataclasses.asdict(report)
+        shape = cq.importers.importStep(step_path)
+        vertices, faces = shape.val().tessellate(0.5)
+        mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+        stl_path = os.path.join(tmp_dir, "mesh.stl")
+        mesh.export(stl_path)
+        report_dict["heatmap"] = generate_heatmap(stl_path)
+        out_json = os.path.join(tmp_dir, "dfm.json")
+        with open(out_json, "w") as fh:
+            json.dump(report_dict, fh)
+        key = f"models/{job.sha256}/dfm.json"
+        _upload_to_s3(out_json, key)
+        job.dfm_json_url = key
+        advance_model_job_status(job, "dfm_ready")
+        db.session.commit()
+        _notify_status(job)
+    except Exception as exc:
+        db.session.rollback()
+        if self.request.retries >= self.max_retries:
+            job.error_message = str(exc)
+            advance_model_job_status(job, "error")
+            db.session.commit()
+            _notify_status(job)
+            raise
+        raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/worker.py
+++ b/worker.py
@@ -1,0 +1,25 @@
+import os
+from celery import Celery
+
+from app import app
+
+broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+backend = os.getenv("CELERY_BACKEND_URL", broker)
+
+celery = Celery(
+    "cadlytics", broker=broker, backend=backend, include=["tasks.conversion", "tasks.dfm"]
+)
+
+celery.conf.update(task_track_started=True, result_expires=3600)
+
+
+class ContextTask(celery.Task):
+    def __call__(self, *args, **kwargs):
+        with app.app_context():
+            return super().__call__(*args, **kwargs)
+
+
+celery.Task = ContextTask
+
+if __name__ == "__main__":
+    celery.start()


### PR DESCRIPTION
## Résumé
- Ajout d'un worker Celery/Redis dédié aux conversions STEP avec contexte Flask
- Tâches `generate_preview` et `generate_final` pour exporter GLB/XKT et pousser sur S3
- Tâche `run_dfm` générant le rapport DFM et la heatmap

## Tests
- `python -m py_compile worker.py tasks/conversion.py tasks/dfm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a628bfc6a48333862f0390522ff012