### PR TITLE
feat: add modular xeokit viewer with preview swap and DFM overlay

### DIFF
--- a/static/js/modules/main_viewer.js
+++ b/static/js/modules/main_viewer.js
@@ -1,0 +1,34 @@
+import { XeokitModelViewer } from "./viewer.js";
+
+const modelId = document.body.dataset.modelId;
+const app = new XeokitModelViewer("viewerCanvas");
+if (modelId) {
+    app.startPolling(modelId);
+}
+
+// --- UI bindings -----------------------------------------------------------
+const qualityBtn = document.getElementById("qualityToggle");
+qualityBtn.addEventListener("click", async () => {
+    const mode = await app.toggleQuality();
+    qualityBtn.textContent = `Qualité : ${mode === "final" ? "Haute" : "Preview"}`;
+});
+
+document.getElementById("heatmapBtn").onclick = () => {
+    app.toggleHeatmap(!app.heatmapActive);
+};
+
+document.getElementById("wireframeBtn").onclick = () => {
+    app.toggleWireframe(!app.edges.enabled);
+};
+
+document.getElementById("snapshotBtn").onclick = () => {
+    const url = app.snapshot();
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "snapshot.png";
+    a.click();
+};
+
+// expose pour tests manuels
+window.viewerApp = app;
+

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -1,0 +1,171 @@
+import {
+    Viewer,
+    XKTLoaderPlugin,
+    EdgesPlugin,
+    SectionPlanesPlugin,
+    DistanceMeasurementsPlugin,
+    AnnotationsPlugin
+} from "@xeokit/xeokit-sdk";
+
+// Gestionnaire de visualisation avec swap preview/final + overlay DFM
+export class XeokitModelViewer extends EventTarget {
+    constructor(canvasId) {
+        super();
+        this.viewer = new Viewer({ canvasId });
+        this.loader = new XKTLoaderPlugin(this.viewer);
+        this.edges = new EdgesPlugin(this.viewer);
+        this.sections = new SectionPlanesPlugin(this.viewer);
+        this.measure = new DistanceMeasurementsPlugin(this.viewer);
+        this.annotations = new AnnotationsPlugin(this.viewer);
+        this.modelId = "model"; // identifiant constant pour swap
+        this.previewUrl = null;
+        this.finalUrl = null;
+        this.currentQuality = null; // 'preview' | 'final'
+        this.heatmapActive = false;
+        this.colorBuffer = null; // stocke vertex/face colors
+    }
+
+    // --- chargement ---------------------------------------------------------
+    async load(url, { quality = "preview" } = {}) {
+        const cam = this.viewer.camera.getState();
+        if (this.model) {
+            this.model.destroy();
+        }
+        this.model = await this.loader.load({ id: this.modelId, src: url });
+        if (this.currentQuality === null) {
+            // première fois -> cadrage automatique
+            this.viewer.cameraFlight.flyTo(this.model); 
+            this.dispatchEvent(new CustomEvent("onAssetLoaded", { detail: { url } }));
+        } else {
+            // upgrade/downgrade -> restituer caméra
+            this.viewer.camera.setState(cam);
+            if (quality === "final") {
+                this.dispatchEvent(new CustomEvent("onAssetUpgraded", { detail: { url } }));
+            }
+        }
+        this.currentQuality = quality;
+        if (this.heatmapActive && this.colorBuffer) {
+            this._applyColors(this.colorBuffer);
+        }
+    }
+
+    // --- polling ------------------------------------------------------------
+    startPolling(apiId) {
+        this.apiId = apiId;
+        this._poll();
+    }
+
+    async _poll() {
+        if (!this.apiId) return;
+        try {
+            const res = await fetch(`/api/models/${this.apiId}`);
+            if (!res.ok) throw new Error("API");
+            const data = await res.json();
+            if (data.preview_ready && !this.previewUrl) {
+                this.previewUrl = data.preview_url;
+                await this.load(this.previewUrl, { quality: "preview" });
+                this._setProgress(0.5);
+            }
+            if (data.final_ready && !this.finalUrl) {
+                this.finalUrl = data.final_url;
+                await this.load(this.finalUrl, { quality: "final" });
+                this._setProgress(0.8);
+            }
+            if (data.dfm_ready) {
+                this._setProgress(1);
+            }
+            if (!data.final_ready) {
+                setTimeout(() => this._poll(), 1500);
+            }
+        } catch (e) {
+            setTimeout(() => this._poll(), 1500);
+        }
+    }
+
+    // --- qualité ------------------------------------------------------------
+    async toggleQuality() {
+        if (this.currentQuality === "preview" && this.finalUrl) {
+            await this.load(this.finalUrl, { quality: "final" });
+            return "final";
+        } else if (this.previewUrl) {
+            await this.load(this.previewUrl, { quality: "preview" });
+            return "preview";
+        }
+    }
+
+    // --- heatmap ------------------------------------------------------------
+    applyHeatmap(buffer) {
+        this.colorBuffer = buffer; // {vertexColors: Float32Array} ou {faceColors: Float32Array}
+        this._applyColors(buffer);
+        this.heatmapActive = true;
+        this.dispatchEvent(new Event("onDFMOverlayToggled"));
+    }
+
+    _applyColors(buffer) {
+        if (!this.model) return;
+        this.model.meshes.forEach((m) => {
+            const g = m.geometry;
+            if (buffer.vertexColors) {
+                g.setColors({ colors: buffer.vertexColors });
+            } else if (buffer.faceColors) {
+                g.setColors({ colors: buffer.faceColors, space: "faces" });
+            }
+        });
+    }
+
+    toggleHeatmap(on) {
+        if (!this.model) return;
+        if (on && this.colorBuffer) {
+            this._applyColors(this.colorBuffer);
+        } else {
+            this.model.meshes.forEach((m) => m.geometry.setColors(null));
+        }
+        this.heatmapActive = on;
+        this.dispatchEvent(new Event("onDFMOverlayToggled"));
+    }
+
+    // --- wireframe ----------------------------------------------------------
+    toggleWireframe(on) {
+        this.edges.enabled = on;
+    }
+
+    // --- DFM issues ---------------------------------------------------------
+    setIssues(issues) {
+        const list = document.getElementById("dfmIssues");
+        if (list) {
+            list.innerHTML = "";
+        }
+        issues
+            .sort((a, b) => a.severity.localeCompare(b.severity))
+            .forEach((iss) => {
+                const ann = this.annotations.createAnnotation({
+                    id: iss.id,
+                    worldPos: iss.worldPos,
+                    text: iss.message,
+                });
+                if (list) {
+                    const li = document.createElement("li");
+                    li.textContent = `${iss.severity} - ${iss.type}`;
+                    li.onclick = () => {
+                        this.viewer.scene.setObjectsVisible(this.viewer.scene.visibleObjects, false);
+                        this.viewer.scene.setObjectVisible(ann.entity.id, true);
+                        this.viewer.cameraFlight.flyTo({ aabb: iss.aabb });
+                    };
+                    list.appendChild(li);
+                }
+            });
+    }
+
+    // --- snapshot -----------------------------------------------------------
+    snapshot() {
+        return this.viewer.getSnapshot({ format: "png" });
+    }
+
+    // --- progression --------------------------------------------------------
+    _setProgress(ratio) {
+        const bar = document.getElementById("progressBar");
+        if (bar) {
+            bar.style.width = `${Math.round(ratio * 100)}%`;
+        }
+    }
+}

--- a/templates/viewer_example.html
+++ b/templates/viewer_example.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8" />
+    <title>Xeokit viewer</title>
+    <style>
+        body,html { margin:0; height:100%; }
+        #toolbar { display:flex; gap:8px; padding:4px; background:#eee; align-items:center; }
+        #progressContainer { flex:1; height:6px; background:#ccc; margin-right:8px; }
+        #progressBar { height:100%; width:0; background:#4caf50; }
+        #viewerCanvas { width:100%; height:calc(100% - 40px); display:block; }
+        #dfmPanel { position:absolute; top:40px; right:0; width:200px; background:rgba(255,255,255,0.9); max-height:50%; overflow:auto; }
+        #dfmPanel ul { list-style:none; padding:0; margin:0; }
+        #dfmPanel li { padding:4px; cursor:pointer; }
+    </style>
+</head>
+<body data-model-id="demo123">
+    <div id="toolbar">
+        <div id="progressContainer"><div id="progressBar"></div></div>
+        <button id="qualityToggle">Qualité : Preview</button>
+        <button id="heatmapBtn">Heatmap</button>
+        <button id="wireframeBtn">Wireframe</button>
+        <button id="snapshotBtn">Snapshot</button>
+    </div>
+    <div id="dfmPanel">
+        <ul id="dfmIssues"></ul>
+    </div>
+    <canvas id="viewerCanvas"></canvas>
+    <script type="module" src="/static/js/modules/main_viewer.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `XeokitModelViewer` module handling preview/final swap, polling and overlays
- wire up toolbar controls (quality, heatmap, wireframe, snapshot)
- provide minimal HTML example with progress bar and DFM panel

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68a6307b7cb48333a983886164f22523