### PR TITLE
feat: support resumable tus uploads

### DIFF
--- a/app.py
+++ b/app.py
@@ -320,10 +320,12 @@ with app.app_context():
 from auth import auth_bp
 from google_auth import google_auth_bp
 from stripe_payment import stripe_bp
+from tus_upload import tus_bp
 
 app.register_blueprint(auth_bp, url_prefix='/auth')
 app.register_blueprint(google_auth_bp)
 app.register_blueprint(stripe_bp, url_prefix='/stripe')
+app.register_blueprint(tus_bp, url_prefix='/tus')
 
 # Make session permanent
 @app.before_request
@@ -603,26 +605,49 @@ def upload():
 
 @app.route('/api/upload', methods=['POST'])
 def api_upload():
-    file = request.files.get('file')
-    if not file:
-        return jsonify({'error': 'missing_file'}), 400
-    filename = secure_filename(file.filename or '')
-    if not filename:
-        return jsonify({'error': 'empty_filename'}), 400
-
-    sha256 = hashlib.sha256()
-    size = 0
-    tmp_path = os.path.join(app.config['UPLOAD_FOLDER'], f"tmp_{uuid.uuid4().hex}")
-    with open(tmp_path, 'wb') as dst:
-        for chunk in iter(lambda: file.stream.read(8192), b''):
-            sha256.update(chunk)
-            size += len(chunk)
-            dst.write(chunk)
-    digest = sha256.hexdigest()
+    data = request.get_json(silent=True) or {}
+    upload_id = data.get('upload_id') if isinstance(data, dict) else None
+    if upload_id:
+        tus_dir = os.path.join(app.config['UPLOAD_FOLDER'], 'tus')
+        file_path = os.path.join(tus_dir, upload_id)
+        info_path = os.path.join(tus_dir, f"{upload_id}.json")
+        if not os.path.exists(file_path) or not os.path.exists(info_path):
+            return jsonify({'error': 'invalid_handle'}), 400
+        with open(info_path) as f:
+            info = json.load(f)
+        filename = secure_filename(info.get('metadata', {}).get('filename') or '')
+        mime_type = info.get('metadata', {}).get('filetype', 'application/octet-stream')
+        sha256 = hashlib.sha256()
+        size = 0
+        with open(file_path, 'rb') as src:
+            for chunk in iter(lambda: src.read(8192), b''):
+                sha256.update(chunk)
+                size += len(chunk)
+        digest = sha256.hexdigest()
+        tmp_path = file_path
+    else:
+        file = request.files.get('file')
+        if not file:
+            return jsonify({'error': 'missing_file'}), 400
+        filename = secure_filename(file.filename or '')
+        if not filename:
+            return jsonify({'error': 'empty_filename'}), 400
+        mime_type = file.mimetype or 'application/octet-stream'
+        sha256 = hashlib.sha256()
+        size = 0
+        tmp_path = os.path.join(app.config['UPLOAD_FOLDER'], f"tmp_{uuid.uuid4().hex}")
+        with open(tmp_path, 'wb') as dst:
+            for chunk in iter(lambda: file.stream.read(8192), b''):
+                sha256.update(chunk)
+                size += len(chunk)
+                dst.write(chunk)
+        digest = sha256.hexdigest()
 
     existing = ModelJob.query.filter_by(sha256=digest).first()
     if existing:
         os.remove(tmp_path)
+        if upload_id:
+            os.remove(info_path)
         logger.info(json.dumps({'action': 'upload', 'result': 'cache_hit', 'job_id': existing.id}))
         return jsonify({
             'modelId': existing.id,
@@ -637,7 +662,7 @@ def api_upload():
         sha256=digest,
         original_filename=filename,
         size_bytes=size,
-        mime=file.mimetype or 'application/octet-stream',
+        mime=mime_type,
         user_id=current_user.id if current_user.is_authenticated else None,
     )
     db.session.add(job)
@@ -645,6 +670,8 @@ def api_upload():
 
     final_path = os.path.join(app.config['UPLOAD_FOLDER'], f"{job.id}.step")
     os.rename(tmp_path, final_path)
+    if upload_id:
+        os.remove(info_path)
 
     generate_preview.delay(job.id)
     generate_final.delay(job.id)

--- a/static/js/tus-upload.js
+++ b/static/js/tus-upload.js
@@ -1,0 +1,100 @@
+// Gestion de l'upload résumable via tus-js-client
+
+(function() {
+  const form = document.getElementById('uploadForm');
+  if (!form) return;
+  const fileInput = document.getElementById('fileInput');
+  const progressSection = document.getElementById('progressSection');
+  const uploadPercent = document.getElementById('uploadPercent');
+  const uploadBar = document.getElementById('uploadBar');
+  const uploadStats = document.getElementById('uploadStats');
+  const cancelBtn = document.getElementById('cancelUpload');
+  const uploadResults = document.getElementById('uploadResults');
+  const errorAlert = document.getElementById('errorAlert');
+  const errorMessage = document.getElementById('errorMessage');
+
+  let currentUpload = null;
+  let lastTime = 0;
+  let lastUploaded = 0;
+
+  function resetProgress() {
+    progressSection.style.display = 'none';
+    uploadBar.style.width = '0%';
+    uploadPercent.textContent = '0%';
+    uploadStats.textContent = '';
+  }
+
+  function showError(msg) {
+    if (errorMessage) errorMessage.textContent = msg;
+    if (errorAlert) errorAlert.style.display = 'block';
+    resetProgress();
+  }
+
+  cancelBtn.addEventListener('click', function() {
+    if (currentUpload) {
+      currentUpload.abort();
+    }
+    resetProgress();
+  });
+
+  form.addEventListener('submit', function(e) {
+    e.preventDefault();
+    const file = fileInput.files[0];
+    if (!file) return;
+    errorAlert.style.display = 'none';
+    uploadResults.style.display = 'none';
+    progressSection.style.display = 'block';
+    lastTime = Date.now();
+    lastUploaded = 0;
+
+    const upload = new tus.Upload(file, {
+      endpoint: '/tus/files',
+      retryDelays: [0, 1000, 3000, 5000],
+      storeFingerprintForResuming: true,
+      removeFingerprintOnSuccess: true,
+      metadata: {
+        filename: file.name,
+        filetype: file.type
+      },
+      onError: function(error) {
+        showError(error.message);
+      },
+      onProgress: function(bytesUploaded, bytesTotal) {
+        const pct = ((bytesUploaded / bytesTotal) * 100).toFixed(1);
+        uploadBar.style.width = pct + '%';
+        uploadPercent.textContent = pct + '%';
+        const now = Date.now();
+        const delta = now - lastTime;
+        if (delta > 0) {
+          const speed = (bytesUploaded - lastUploaded) / (delta / 1000); // B/s
+          const remaining = bytesTotal - bytesUploaded;
+          const eta = speed > 0 ? remaining / speed : 0;
+          uploadStats.textContent = `${(speed / 1024 / 1024).toFixed(2)} MB/s, ETA ${eta.toFixed(1)} s`;
+          lastTime = now;
+          lastUploaded = bytesUploaded;
+        }
+      },
+      onSuccess: function() {
+        const url = upload.url;
+        const id = url.split('/').pop();
+        fetch('/api/upload', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ upload_id: id })
+        })
+          .then(r => r.json())
+          .then(data => {
+            if (data && data.modelId) {
+              uploadResults.style.display = 'block';
+            } else {
+              showError(data.error || 'Erreur serveur');
+            }
+          })
+          .catch(() => showError('Erreur réseau'));
+      }
+    });
+
+    currentUpload = upload;
+    upload.start();
+  });
+})();

--- a/templates/index.html
+++ b/templates/index.html
@@ -20,6 +20,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
     
     <script type="module" src="/static/dist/main.js"></script>
+    <script src="https://unpkg.com/tus-js-client@3.1.0/dist/tus.min.js"></script>
+    <script src="{{ url_for('static', filename='js/tus-upload.js') }}"></script>
 
     <!-- Plausible Analytics -->
     <script async defer data-domain="cadlytics.replit.app" src="https://plausible.io/js/script.js"></script>
@@ -134,18 +136,12 @@
                 <div id="progressSection" class="mt-4" style="display: none;">
                     <div class="card">
                         <div class="card-body text-center">
-                            <div class="spinner-border text-primary mb-3" role="status">
-                                <span class="visually-hidden">Chargement...</span>
-                            </div>
-                            <h6 style="color: var(--brown-dark);">Conversion en cours...</h6>
-                            <p class="small" style="color: var(--brown-medium);">
-                                La conversion peut prendre jusqu'à 30 secondes pour les fichiers complexes.
-                            </p>
+                            <h6 id="uploadPercent" style="color: var(--brown-dark);">0%</h6>
+                            <p id="uploadStats" class="small" style="color: var(--brown-medium);"></p>
                             <div class="progress">
-                                <div class="progress-bar progress-bar-striped progress-bar-animated" 
-                                     role="progressbar" style="width: 100%">
-                                </div>
+                                <div id="uploadBar" class="progress-bar progress-bar-striped" role="progressbar" style="width: 0%"></div>
                             </div>
+                            <button type="button" class="btn btn-link mt-2" id="cancelUpload">Annuler</button>
                         </div>
                     </div>
                 </div>

--- a/tests/test_tus_upload.py
+++ b/tests/test_tus_upload.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import json
+import pathlib
+import types
+import pytest
+
+sys.modules.setdefault('cadquery', types.SimpleNamespace())
+sys.modules.setdefault('trimesh', types.SimpleNamespace())
+dummy = types.SimpleNamespace()
+sys.modules.setdefault('OCP', types.SimpleNamespace(STEPControl=dummy, StlAPI=dummy, Interface=dummy))
+sys.modules.setdefault('OCP.STEPControl', types.SimpleNamespace(STEPControl_Reader=dummy))
+sys.modules.setdefault('OCP.StlAPI', types.SimpleNamespace(StlAPI_Writer=dummy))
+sys.modules.setdefault('OCP.Interface', types.SimpleNamespace(Interface_Static=dummy))
+google_stub = types.SimpleNamespace()
+flask_dance_google = types.SimpleNamespace(make_google_blueprint=lambda **k: google_stub, google=google_stub)
+sys.modules.setdefault('flask_dance', types.SimpleNamespace(contrib=types.SimpleNamespace(google=flask_dance_google)))
+sys.modules.setdefault('flask_dance.contrib', types.SimpleNamespace(google=flask_dance_google))
+sys.modules.setdefault('flask_dance.contrib.google', flask_dance_google)
+class _OAuthConsumerMixin: pass
+storage_sqla = types.SimpleNamespace(OAuthConsumerMixin=_OAuthConsumerMixin)
+storage_module = types.SimpleNamespace(sqla=storage_sqla)
+consumer_module = types.SimpleNamespace(storage=storage_module)
+sys.modules.setdefault('flask_dance.consumer', consumer_module)
+sys.modules.setdefault('flask_dance.consumer.storage', storage_module)
+sys.modules.setdefault('flask_dance.consumer.storage.sqla', storage_sqla)
+class _UserMixin: pass
+login_module = types.SimpleNamespace(
+    UserMixin=_UserMixin,
+    LoginManager=lambda: None,
+    login_required=lambda f: f,
+    current_user=types.SimpleNamespace(is_authenticated=False, id=None)
+)
+sys.modules.setdefault('flask_login', login_module)
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from app import app, db, generate_preview, generate_final
+
+
+def _client(tmp_path):
+    app.config['TESTING'] = True
+    app.config['UPLOAD_FOLDER'] = str(tmp_path)
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite://'
+    with app.app_context():
+        db.drop_all()
+        db.create_all()
+    generate_preview.delay = lambda *a, **k: None
+    generate_final.delay = lambda *a, **k: None
+    return app.test_client()
+
+
+def test_resumable_upload_resume(tmp_path):
+    client = _client(tmp_path)
+    create = client.post('/tus/files', headers={'Upload-Length': '11', 'Tus-Resumable': '1.0.0'})
+    assert create.status_code == 201
+    upload_id = create.headers['Location'].split('/')[-1]
+    r = client.patch(f'/tus/files/{upload_id}', data=b'hello', headers={
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': '0',
+        'Content-Type': 'application/offset+octet-stream'
+    })
+    assert r.status_code == 204
+    head = client.head(f'/tus/files/{upload_id}', headers={'Tus-Resumable': '1.0.0'})
+    assert head.headers['Upload-Offset'] == '5'
+    r = client.patch(f'/tus/files/{upload_id}', data=b' world', headers={
+        'Tus-Resumable': '1.0.0',
+        'Upload-Offset': '5',
+        'Content-Type': 'application/offset+octet-stream'
+    })
+    assert r.status_code == 204
+    head = client.head(f'/tus/files/{upload_id}', headers={'Tus-Resumable': '1.0.0'})
+    assert head.headers['Upload-Offset'] == '11'
+    path = os.path.join(tmp_path, 'tus', upload_id)
+    with open(path, 'rb') as f:
+        assert f.read() == b'hello world'
+    resp = client.post('/api/upload', json={'upload_id': upload_id})
+    assert resp.status_code == 201
+
+
+def test_upload_rejects_large_file(tmp_path):
+    client = _client(tmp_path)
+    too_big = str(2 * 1024 * 1024 * 1024 + 1)
+    resp = client.post('/tus/files', headers={'Upload-Length': too_big, 'Tus-Resumable': '1.0.0'})
+    assert resp.status_code == 413

--- a/tus_upload.py
+++ b/tus_upload.py
@@ -1,0 +1,112 @@
+import os
+import uuid
+import json
+import base64
+from flask import Blueprint, request, current_app, abort, Response
+
+
+# Blueprint implementing a minimal tus.io server
+# Stores uploads in <UPLOAD_FOLDER>/tus
+
+
+tus_bp = Blueprint('tus', __name__)
+TUS_VERSION = '1.0.0'
+MAX_SIZE = 2 * 1024 * 1024 * 1024  # 2GB
+
+
+def _tus_dir():
+    root = os.path.join(current_app.config['UPLOAD_FOLDER'], 'tus')
+    os.makedirs(root, exist_ok=True)
+    return root
+
+
+def _info_path(upload_id):
+    return os.path.join(_tus_dir(), f"{upload_id}.json")
+
+
+def _file_path(upload_id):
+    return os.path.join(_tus_dir(), upload_id)
+
+
+def _load_info(upload_id):
+    p = _info_path(upload_id)
+    if not os.path.exists(p):
+        return None
+    with open(p) as f:
+        return json.load(f)
+
+
+def _save_info(upload_id, info):
+    with open(_info_path(upload_id), 'w') as f:
+        json.dump(info, f)
+
+
+@tus_bp.route('/files', methods=['OPTIONS'])
+@tus_bp.route('/files/<upload_id>', methods=['OPTIONS'])
+def tus_options(upload_id=None):
+    resp = Response(status=204)
+    resp.headers['Tus-Resumable'] = TUS_VERSION
+    resp.headers['Tus-Version'] = TUS_VERSION
+    resp.headers['Tus-Extension'] = 'creation'
+    resp.headers['Access-Control-Allow-Methods'] = 'POST,HEAD,PATCH,OPTIONS'
+    resp.headers['Access-Control-Allow-Headers'] = 'Tus-Resumable,Upload-Length,Upload-Offset,Content-Type,Upload-Metadata'
+    return resp
+
+
+@tus_bp.route('/files', methods=['POST'])
+def tus_create():
+    upload_length = request.headers.get('Upload-Length')
+    if upload_length is None:
+        abort(400)
+    upload_length = int(upload_length)
+    if upload_length > MAX_SIZE:
+        return Response(status=413)
+
+    meta_hdr = request.headers.get('Upload-Metadata', '')
+    metadata = {}
+    if meta_hdr:
+        for kv in meta_hdr.split(','):
+            if ' ' in kv:
+                k, v = kv.split(' ', 1)
+                metadata[k] = base64.b64decode(v).decode('utf-8')
+    upload_id = uuid.uuid4().hex
+    info = {'upload_length': upload_length, 'offset': 0, 'metadata': metadata}
+    _save_info(upload_id, info)
+    open(_file_path(upload_id), 'wb').close()
+    resp = Response(status=201)
+    resp.headers['Location'] = f"/tus/files/{upload_id}"
+    resp.headers['Tus-Resumable'] = TUS_VERSION
+    resp.headers['Upload-Offset'] = '0'
+    return resp
+
+
+@tus_bp.route('/files/<upload_id>', methods=['HEAD'])
+def tus_head(upload_id):
+    info = _load_info(upload_id)
+    if not info:
+        abort(404)
+    resp = Response(status=200)
+    resp.headers['Tus-Resumable'] = TUS_VERSION
+    resp.headers['Upload-Offset'] = str(info['offset'])
+    resp.headers['Upload-Length'] = str(info['upload_length'])
+    return resp
+
+
+@tus_bp.route('/files/<upload_id>', methods=['PATCH'])
+def tus_patch(upload_id):
+    info = _load_info(upload_id)
+    if not info:
+        abort(404)
+    upload_offset = int(request.headers.get('Upload-Offset', 0))
+    if upload_offset != info['offset']:
+        return Response(status=409)
+    chunk = request.get_data()
+    file_path = _file_path(upload_id)
+    with open(file_path, 'ab') as f:
+        f.write(chunk)
+    info['offset'] += len(chunk)
+    _save_info(upload_id, info)
+    resp = Response(status=204)
+    resp.headers['Tus-Resumable'] = TUS_VERSION
+    resp.headers['Upload-Offset'] = str(info['offset'])
+    return resp


### PR DESCRIPTION
## Summary
- add minimal tus.io server blueprint and integrate with existing upload flow
- implement frontend resumable upload with progress, speed, ETA and cancel
- provide tests for tus upload resume and size limit

## Testing
- `pytest tests/test_tus_upload.py -q` *(fails: Can't create UniqueConstraint on table 'o_auth': no column named 'provider')*


------
https://chatgpt.com/codex/tasks/task_e_68a6327a1ea0833388eed623d65ff743