### PR TITLE
Centralise l'initialisation de Celery

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from heatmap import generate_heatmap
 from material_recommender import recommend_materials_for_questionnaire
 import xkt_converter
 from tasks.conversion import generate_preview, generate_final
+from celery_app import celery, init_celery
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
 from log import log_action
@@ -101,24 +102,7 @@ app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
 db.init_app(app)
 migrate = Migrate(app, db)
 
-# Celery pour traiter les conversions en arrière-plan
-from celery import Celery
-
-def make_celery(flask_app):
-    broker = os.getenv('CELERY_BROKER_URL', 'redis://localhost:6379/0')
-    celery = Celery(flask_app.import_name, broker=broker, backend=broker)
-    celery.conf.update(flask_app.config)
-    celery.conf.update(task_always_eager=flask_app.config['CELERY_TASK_ALWAYS_EAGER'])
-
-    class ContextTask(celery.Task):
-        def __call__(self, *args, **kwargs):
-            with flask_app.app_context():
-                return super().__call__(*args, **kwargs)
-
-    celery.Task = ContextTask
-    return celery
-
-celery = make_celery(app)
+init_celery(app)
 from celery.schedules import crontab
 
 celery.conf.beat_schedule = {

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,0 +1,19 @@
+import os
+from celery import Celery
+
+celery = Celery("cadlytics", include=["tasks.conversion", "tasks.dfm"])
+
+
+def init_celery(app):
+    broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+    backend = os.getenv("CELERY_BACKEND_URL", broker)
+    celery.conf.update(broker_url=broker, result_backend=backend)
+    celery.conf.update(app.config)
+
+    class ContextTask(celery.Task):
+        def __call__(self, *args, **kwargs):
+            with app.app_context():
+                return super().__call__(*args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/tasks/conversion.py
+++ b/tasks/conversion.py
@@ -11,7 +11,7 @@ from PIL import Image
 from flask import current_app
 
 from models import db, ModelJob, advance_model_job_status
-from worker import celery
+from celery_app import celery
 from tasks.dfm import run_dfm
 from storage.s3 import put_asset
 from observability.logging import get_logger

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -10,7 +10,7 @@ import trimesh
 from flask import current_app
 
 from models import db, ModelJob, advance_model_job_status
-from worker import celery
+from celery_app import celery
 from dfm_analyzer import analyze_dfm
 from heatmap import generate_heatmap
 from storage.s3 import put_asset

--- a/worker.py
+++ b/worker.py
@@ -1,27 +1,6 @@
-import os
-from celery import Celery
-
-from app import app
+from celery_app import celery
 from observability.logging import get_logger
 from celery import signals
-
-broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-backend = os.getenv("CELERY_BACKEND_URL", broker)
-
-celery = Celery(
-    "cadlytics", broker=broker, backend=backend, include=["tasks.conversion", "tasks.dfm"]
-)
-
-celery.conf.update(task_track_started=True, result_expires=3600)
-
-
-class ContextTask(celery.Task):
-    def __call__(self, *args, **kwargs):
-        with app.app_context():
-            return super().__call__(*args, **kwargs)
-
-
-celery.Task = ContextTask
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- Déplace l'instanciation de Celery dans `celery_app.py` avec `init_celery`
- Initialise Celery depuis `app.py` et simplifie `worker.py`
- Adapte les tâches pour utiliser le Celery global

## Testing
- `pytest` *(échoue : ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_68a6418412dc8333974d79e8639a4e60