### PR TITLE
fix: defer upload script

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -20,8 +20,8 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
     
     <script type="module" src="/static/dist/main.js"></script>
-    <script src="https://unpkg.com/tus-js-client@3.1.0/dist/tus.min.js"></script>
-    <script src="{{ url_for('static', filename='js/tus-upload.js') }}"></script>
+    <script defer src="https://unpkg.com/tus-js-client@3.1.0/dist/tus.min.js"></script>
+    <script defer src="{{ url_for('static', filename='js/tus-upload.js') }}"></script>
 
     <!-- Plausible Analytics -->
     <script async defer data-domain="cadlytics.replit.app" src="https://plausible.io/js/script.js"></script>


### PR DESCRIPTION
## Summary
- defer tus-upload scripts to initialize upload zone after DOM load

## Testing
- `pytest` *(errors: No module named 'dfm', No module named 'flask_migrate')*


------
https://chatgpt.com/codex/tasks/task_e_68a6b892cf748333a664de84faff6da9