### PR TITLE
Expose xktUrl in conversion API response

### DIFF
--- a/app.py
+++ b/app.py
@@ -489,7 +489,8 @@ def convert_step():
 
     logger.info("Conversion OK en %.2fs -> %s", time.time() - start, out_path)
     # La route /uploads/<fname> doit servir CONVERTED_FOLDER
-    return jsonify(success=True, url=f"/uploads/{out_name}")
+    xkt_rel_url = f"/uploads/{out_name}"
+    return jsonify(success=True, url=xkt_rel_url, xktUrl=xkt_rel_url)
 
 
 @app.route('/upload_file', methods=['POST'])


### PR DESCRIPTION
## Summary
- return both `url` and `xktUrl` from `/convert`

## Testing
- `pytest` *(fails: No module named 'requests')*
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a77bc7a0c48333a3f439f0a76272a5