### PR TITLE
Integrate questionnaire criteria into material selection

### DIFF
--- a/app.py
+++ b/app.py
@@ -1231,7 +1231,17 @@ Créé par Grégoire GOUNY
 @app.route('/dfm/analyze', methods=['POST'])
 def analyze_and_recommend():
     """Simple endpoint to handle DFM analysis and material recommendations"""
-    questionnaire = request.form.to_dict()
+    questionnaire = {
+        'application': request.form.get('application', ''),
+        'mechanical': request.form.getlist('mechanical[]'),
+        'temperature': request.form.get('temperature', ''),
+        'exposure': request.form.getlist('exposure[]'),
+        'aesthetic': request.form.getlist('aesthetic[]'),
+        'regulatory': request.form.getlist('regulatory[]'),
+        'cost': request.form.get('cost', ''),
+        'volume': request.form.get('volume'),
+        'lifespan': request.form.get('lifespan'),
+    }
     recos = recommend_materials_for_questionnaire(questionnaire, {})
     return jsonify({'success': True, 'recommendations': recos})
 

--- a/src/main.js
+++ b/src/main.js
@@ -223,9 +223,7 @@ function bindUI() {
       e.preventDefault();
       e.stopPropagation();
       const materialForm = materialModal?.querySelector("form");
-      const payload = materialForm
-        ? Object.fromEntries(new FormData(materialForm).entries())
-        : {};
+      const formData = materialForm ? new FormData(materialForm) : new FormData();
       try {
         const m =
           bootstrap.Modal.getInstance(materialModal) ||
@@ -237,7 +235,7 @@ function bindUI() {
           materialModal.style.display = "none";
         }
       }
-      startDFMProcess(payload);
+      startDFMProcess(formData);
     });
   }
 
@@ -266,16 +264,12 @@ function bindUI() {
   setupTooltip();
 }
 
-async function startDFMProcess(materialChoices = {}) {
+async function startDFMProcess(materialFormData = new FormData()) {
   try {
     const res = await fetch("/dfm/analyze", {
       method: "POST",
       headers: { Accept: "application/json" },
-      body: (() => {
-        const fd = new FormData();
-        Object.entries(materialChoices).forEach(([k, v]) => fd.append(k, v));
-        return fd;
-      })(),
+      body: materialFormData,
     });
     if (!res.ok) throw new Error("DFM HTTP " + res.status);
     const data = await res.json();


### PR DESCRIPTION
## Summary
- Pass questionnaire form data with multi-select fields directly from the material selection modal
- Parse form lists on the `/dfm/analyze` route so recommendations honor all chosen criteria

## Testing
- `pytest tests/test_export.py tests/test_tus_upload.py -q` *(fails: ModuleNotFoundError: No module named 'dfm'; sqlalchemy.exc.ConstraintColumnNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68ab694cd658833397c42fffba734809