### PR TITLE
feat: enforce material selection rules

### DIFF
--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -1,192 +1,279 @@
-// Gestion des critères du modal de sélection matière
+// Logiciel de sélection des critères matière
+// Applique les règles exclusives, conflits et limites puis gère le bouton "Analyser".
 
-// Déclaration des règles
-const rules = {
-    exclusives: [
-        ["rigidite_elevee", "flexibilite"],
-        ["transparence", "charge_fibre"]
-    ],
-    conflicts: {
-        transparence: {
-            hard: ["retardateur_flamme"],
-            soft: ["texture_possible"]
-        }
+// === Déclaration des règles métiers ===
+const RULES = {
+  limits: { meca: 3, aesthetic: 2, regulatory: 1 },
+  exclusiveGroups: [
+    ["rigidite_elevee", "flexibilite"],
+    ["transparence", "charge_fibre"],
+  ],
+  conflicts: [
+    {
+      a: "transparence",
+      b: "retardateur_flamme",
+      severity: "hard",
+      msg: "Incompatibles : les retardateurs de flamme rendent opaque.",
     },
-    limits: {
-        mecanique: 3,
-        esthetique: 2,
-        reglementaire: 1
+    {
+      a: "transparence",
+      b: "texture_possible",
+      severity: "soft",
+      msg: "La texture forte réduit la transparence perçue.",
     },
-    regStrong: ["alimentaire", "medicale", "retardateur_flamme", "electrique"]
+  ],
+  regulatoryStrong: [
+    "contact_alimentaire",
+    "qualite_medicale",
+    "retardateur_flamme",
+    "proprietes_elec",
+  ],
 };
 
-// Mapping exclusifs pour accès rapide
-const exclusiveMap = {};
-rules.exclusives.forEach(([a, b]) => {
-    exclusiveMap[a] = (exclusiveMap[a] || []).concat(b);
-    exclusiveMap[b] = (exclusiveMap[b] || []).concat(a);
+// Mapping section → critères
+const SECTION_MAP = {
+  meca: [
+    "rigidite_elevee",
+    "flexibilite",
+    "resistance_chocs",
+    "flexion",
+    "traction",
+    "usure",
+    "fatigue",
+  ],
+  aesthetic: [
+    "transparence",
+    "qualite_surface",
+    "texture_possible",
+    "finition_bril",
+  ],
+  regulatory: [
+    "contact_alimentaire",
+    "qualite_medicale",
+    "retardateur_flamme",
+    "proprietes_elec",
+  ],
+};
+
+// Pré-calculs pour accès rapide
+const EXCLUSIVE_LOOKUP = {};
+RULES.exclusiveGroups.forEach((group) => {
+  group.forEach((id) => {
+    EXCLUSIVE_LOOKUP[id] = group.filter((x) => x !== id);
+  });
+});
+
+const CONFLICT_MAP = {};
+RULES.conflicts.forEach(({ a, b, severity, msg }) => {
+  (CONFLICT_MAP[a] = CONFLICT_MAP[a] || []).push({ other: b, severity, msg });
+  (CONFLICT_MAP[b] = CONFLICT_MAP[b] || []).push({ other: a, severity, msg });
 });
 
 const state = {
-    warnings: new Set(),
-    blockers: new Set()
+  warnings: new Set(),
+  blockers: new Set(),
 };
 
-function showToast(message) {
-    const container = document.getElementById("toastContainer");
-    if (!container) return;
-    const toastEl = document.createElement("div");
-    toastEl.className = "toast";
-    toastEl.innerHTML = `<div class="toast-body">${message}</div>`;
-    container.appendChild(toastEl);
-    const toast = new bootstrap.Toast(toastEl);
-    toast.show();
-    toastEl.addEventListener("hidden.bs.toast", () => toastEl.remove());
+// === Utilitaires ===
+function sectionOf(id) {
+  const el = document.getElementById(id);
+  return el?.dataset.section ||
+    Object.keys(SECTION_MAP).find((k) => SECTION_MAP[k].includes(id));
 }
 
-function addWarningBadge(id) {
-    const label = document.querySelector(`label[for="${id}"]`);
-    if (label && !label.querySelector(".warn-badge")) {
-        const span = document.createElement("span");
-        span.className = "warn-badge badge text-bg-warning ms-2";
-        span.textContent = "⚠️";
-        label.appendChild(span);
-    }
+function isChecked(id) {
+  return document.getElementById(id)?.checked || false;
 }
 
-function removeWarningBadge(id) {
-    const label = document.querySelector(`label[for="${id}"]`);
-    if (!label) return;
-    const badge = label.querySelector(".warn-badge");
-    if (badge) badge.remove();
+function setChecked(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.checked = value;
 }
 
-function exceedsSectionLimit(cb) {
-    const section = cb.dataset.section;
-    const limit = rules.limits[section];
-    if (!limit) return false;
-    const checked = document.querySelectorAll(`.criterion[data-section="${section}"]:checked`);
-    if (checked.length > limit) {
-        showToast("Max atteint dans cette section");
-        return true;
+function toast(message) {
+  if (window.bootstrap?.Toast) {
+    let c = document.getElementById("toastContainer");
+    if (!c) {
+      c = document.createElement("div");
+      c.id = "toastContainer";
+      c.className = "toast-container position-fixed bottom-0 end-0 p-3";
+      document.body.appendChild(c);
     }
-    if (section === "reglementaire" && rules.regStrong.includes(cb.id)) {
-        const strongChecked = Array.from(checked).filter(x => rules.regStrong.includes(x.id));
-        if (strongChecked.length > rules.limits.reglementaire) {
-            showToast("Max atteint dans cette section");
-            return true;
-        }
+    const el = document.createElement("div");
+    el.className = "toast";
+    el.innerHTML = `<div class="toast-body">${message}</div>`;
+    c.appendChild(el);
+    const t = new bootstrap.Toast(el);
+    t.show();
+    el.addEventListener("hidden.bs.toast", () => el.remove());
+  } else {
+    alert(message);
+  }
+}
+
+function shake(el) {
+  if (!el) return;
+  el.classList.add("shake");
+  setTimeout(() => el.classList.remove("shake"), 400);
+}
+
+function updateSummary() {
+  const checked = Array.from(
+    document.querySelectorAll(".criterion:checked")
+  ).map((cb) => cb.id);
+  const valids = checked.filter(
+    (id) => !state.warnings.has(id) && !state.blockers.has(id)
+  );
+  const summary = document.getElementById("criteriaSummary");
+  if (summary) {
+    summary.textContent = `✅ Valides: ${valids.length} | ⚠️ Avertissements: ${state.warnings.size} | ⛔ Blocants: ${state.blockers.size}`;
+  }
+  const btn = document.getElementById("analyserBtn");
+  if (btn) btn.disabled = state.blockers.size > 0;
+}
+
+// === Règles ===
+function enforceExclusives(id) {
+  const others = EXCLUSIVE_LOOKUP[id] || [];
+  others.forEach((oid) => {
+    const el = document.getElementById(oid);
+    if (!el) return;
+    if (isChecked(id)) {
+      setChecked(oid, false);
+      el.disabled = true;
+      el.classList.add("temp-disabled");
+      setTimeout(() => {
+        el.disabled = false;
+        el.classList.remove("temp-disabled");
+      }, 2000);
     }
+  });
+}
+
+function checkLimits(cb) {
+  const section = sectionOf(cb.id);
+  const limit = RULES.limits[section];
+  if (!limit) return true;
+  const checked = document.querySelectorAll(
+    `.criterion[data-section="${section}"]:checked`
+  );
+  if (checked.length > limit) {
+    toast("Maximum atteint dans cette section");
     return false;
+  }
+  if (
+    section === "regulatory" &&
+    RULES.regulatoryStrong.includes(cb.id)
+  ) {
+    const strong = Array.from(checked).filter((x) =>
+      RULES.regulatoryStrong.includes(x.id)
+    );
+    if (strong.length > RULES.limits.regulatory) {
+      toast("Maximum atteint dans cette section");
+      return false;
+    }
+  }
+  return true;
 }
 
 function checkHardConflicts(id) {
-    const allConflicts = [];
-    const direct = rules.conflicts[id]?.hard || [];
-    allConflicts.push(...direct);
-    for (const [k, v] of Object.entries(rules.conflicts)) {
-        if (v.hard && v.hard.includes(id)) allConflicts.push(k);
+  const conflicts = CONFLICT_MAP[id] || [];
+  for (const { other, severity, msg } of conflicts) {
+    if (severity === "hard" && isChecked(other)) {
+      toast(msg);
+      shake(document.getElementById(id));
+      return false;
     }
-    for (const otherId of allConflicts) {
-        const other = document.getElementById(otherId);
-        if (other && other.checked) {
-            showToast(`Conflit avec ${otherId.replace(/_/g, " ")}`);
-            return false;
-        }
-    }
-    return true;
-}
-
-function applyExclusives(id, checked) {
-    const targets = exclusiveMap[id] || [];
-    targets.forEach(tid => {
-        const other = document.getElementById(tid);
-        if (!other) return;
-        if (checked) {
-            other.checked = false;
-            other.disabled = true;
-        } else {
-            other.disabled = false;
-        }
-    });
+  }
+  return true;
 }
 
 function evaluate() {
-    state.warnings.clear();
-    state.blockers.clear();
-    document.querySelectorAll("label .warn-badge").forEach(b => b.remove());
-    const checked = Array.from(document.querySelectorAll(".criterion:checked")).map(cb => cb.id);
+  state.warnings.clear();
+  state.blockers.clear();
+  document
+    .querySelectorAll("label[for]")
+    .forEach((l) => l.classList.remove("text-warning"));
 
-    checked.forEach(id => {
-        const conf = rules.conflicts[id];
-        if (!conf) return;
-        (conf.hard || []).forEach(other => {
-            if (checked.includes(other)) {
-                state.blockers.add(id);
-                state.blockers.add(other);
-            }
-        });
-        (conf.soft || []).forEach(other => {
-            if (checked.includes(other)) {
-                state.warnings.add(id);
-                state.warnings.add(other);
-                addWarningBadge(id);
-                addWarningBadge(other);
-            }
-        });
-    });
+  const checked = Array.from(
+    document.querySelectorAll(".criterion:checked")
+  ).map((cb) => cb.id);
 
-    updateSummary(checked);
-    const btn = document.getElementById("analyserBtn");
-    if (btn) btn.disabled = state.blockers.size > 0;
-}
-
-function updateSummary(checked) {
-    const valid = checked.filter(id => !state.warnings.has(id) && !state.blockers.has(id));
-    fillList("summaryValid", valid);
-    fillList("summaryWarnings", Array.from(state.warnings));
-    fillList("summaryBlockers", Array.from(state.blockers));
-}
-
-function fillList(id, items) {
-    const el = document.getElementById(id);
-    if (!el) return;
-    el.innerHTML = "";
-    items.forEach(it => {
-        const li = document.createElement("li");
-        li.textContent = it.replace(/_/g, " ");
-        el.appendChild(li);
-    });
-}
-
-function handleChange(e) {
-    const cb = e.target;
-    if (cb.checked) {
-        if (exceedsSectionLimit(cb)) {
-            cb.checked = false;
-            return;
+  checked.forEach((id) => {
+    (CONFLICT_MAP[id] || []).forEach(({ other, severity }) => {
+      if (checked.includes(other)) {
+        if (severity === "hard") {
+          state.blockers.add(id);
+          state.blockers.add(other);
+        } else {
+          state.warnings.add(id);
+          state.warnings.add(other);
         }
-        if (!checkHardConflicts(cb.id)) {
-            cb.checked = false;
-            return;
-        }
-        applyExclusives(cb.id, true);
-        const soft = rules.conflicts[cb.id]?.soft || [];
-        soft.forEach(otherId => {
-            const other = document.getElementById(otherId);
-            if (other && other.checked) {
-                showToast(`Avertissement: ${cb.id.replace(/_/g, " ")} et ${otherId.replace(/_/g, " ")}`);
-            }
-        });
-    } else {
-        applyExclusives(cb.id, false);
-    }
-    evaluate();
+      }
+    });
+  });
+
+  state.warnings.forEach((id) => {
+    document
+      .querySelector(`label[for="${id}"]`)
+      ?.classList.add("text-warning");
+  });
+
+  updateSummary();
 }
 
+// === Validation et lancement DFM ===
+function validateForm() {
+  evaluate();
+  const payload = Array.from(
+    document.querySelectorAll(".criterion:checked")
+  ).map((cb) => cb.id);
+  return {
+    ok: state.blockers.size === 0,
+    hardErrors: Array.from(state.blockers),
+    softWarnings: Array.from(state.warnings),
+    payload,
+  };
+}
+
+function onAnalyseClick(e) {
+  const res = validateForm();
+  if (!res.ok) {
+    e.preventDefault();
+    const first = document.getElementById(res.hardErrors[0]);
+    first?.scrollIntoView({ behavior: "smooth", block: "center" });
+    first?.focus();
+    return;
+  }
+  if (typeof startDFM === "function") {
+    startDFM(res.payload);
+  } else {
+    document.dispatchEvent(
+      new CustomEvent("start-dfm", { detail: res.payload })
+    );
+  }
+}
+
+// === Initialisation ===
 document.addEventListener("DOMContentLoaded", () => {
-    document.querySelectorAll(".criterion").forEach(cb => {
-        cb.addEventListener("change", handleChange);
+  document.querySelectorAll(".criterion").forEach((cb) => {
+    cb.addEventListener("change", (e) => {
+      const el = e.target;
+      if (el.checked) {
+        if (!checkLimits(el) || !checkHardConflicts(el.id)) {
+          el.checked = false;
+          return;
+        }
+      }
+      enforceExclusives(el.id);
+      evaluate();
     });
-    evaluate();
+  });
+
+  document
+    .getElementById("analyserBtn")
+    ?.addEventListener("click", onAnalyseClick);
+
+  evaluate();
 });
+


### PR DESCRIPTION
## Summary
- implement declarative rules for material questionnaire (exclusive groups, conflicts, section limits)
- update modal summary and analyser button state
- trigger DFM via startDFM or start-dfm event

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests', 'cadquery', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68ab746edb7c83339078e027414f6ad8