### PR TITLE
feat: adapter for DFM overlays

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -118,8 +118,8 @@ export function renderResults(results) {
 
   const viewer = window.viewerAdapter;
   if (viewer) {
-    if (results.heatmap) viewer.loadHeatmap?.(results.heatmap);
-    if (results.annotations) viewer.loadAnnotations?.(results.annotations);
+    if (results.heatmap) viewer.applyHeatmap?.(results.heatmap);
+    if (results.annotations) viewer.addAnnotations?.(results.annotations);
   }
 }
 

--- a/static/js/modules/DFMViewerAdapter.js
+++ b/static/js/modules/DFMViewerAdapter.js
@@ -1,0 +1,65 @@
+import { AnnotationsPlugin } from "@xeokit/xeokit-sdk";
+
+// Interface d'affichage entre les résultats DFM et Xeokit
+export class DFMViewerAdapter {
+  constructor(viewerApp) {
+    this.app = viewerApp;
+    this.viewer = viewerApp.viewer || viewerApp;
+    this.annotations = viewerApp.annotations || new AnnotationsPlugin(this.viewer);
+    this._annotIds = [];
+    this._coloredMeshes = [];
+  }
+
+  // Applique une heatmap. Préfère le per-vertex, fallback sur per-face.
+  applyHeatmap(heatmap) {
+    const model = this.app.model;
+    if (!model || !heatmap) return;
+    this._coloredMeshes = [];
+    model.meshes.forEach(m => {
+      const g = m.geometry;
+      let ok = false;
+      if (heatmap.vertexColors) {
+        try {
+          g.setColors({ colors: heatmap.vertexColors });
+          ok = true;
+        } catch (_) { /* fallback */ }
+      }
+      if (!ok && heatmap.faceColors) {
+        try {
+          g.setColors({ colors: heatmap.faceColors, space: "faces" });
+          ok = true;
+        } catch (_) { /* ignore */ }
+      }
+      if (ok) this._coloredMeshes.push(m);
+    });
+  }
+
+  // Ajoute des annotations cliquables qui zooment sur la zone.
+  addAnnotations(annotations = []) {
+    annotations.forEach(a => {
+      const ann = this.annotations.createAnnotation({
+        id: a.id,
+        worldPos: a.worldPos,
+        text: a.label
+      });
+      ann.on("click", () => {
+        if (a.aabb) {
+          this.viewer.cameraFlight.flyTo({ aabb: a.aabb });
+        } else if (a.worldPos) {
+          this.viewer.cameraFlight.flyTo({ look: a.worldPos });
+        }
+      });
+      this._annotIds.push(ann.id);
+    });
+  }
+
+  // Supprime heatmap + annotations
+  clearDFMOverlays() {
+    this._coloredMeshes.forEach(m => m.geometry.setColors(null));
+    this._coloredMeshes = [];
+    this._annotIds.forEach(id => this.annotations.removeAnnotation(id));
+    this._annotIds = [];
+  }
+}
+
+export default DFMViewerAdapter;

--- a/static/js/modules/main_viewer.js
+++ b/static/js/modules/main_viewer.js
@@ -1,7 +1,10 @@
 import { XeokitModelViewer } from "./viewer.js";
+import DFMViewerAdapter from "./DFMViewerAdapter.js";
 
 const modelId = document.body.dataset.modelId;
 const app = new XeokitModelViewer("viewerCanvas");
+const viewerAdapter = new DFMViewerAdapter(app);
+window.viewerAdapter = viewerAdapter;
 if (modelId) {
     app.startPolling(modelId);
 }


### PR DESCRIPTION
## Summary
- add adapter wrapping Xeokit viewer for heatmaps and annotations
- expose adapter via main viewer and use it in DFM orchestrator

## Testing
- `npm test` (fails: Error: no test specified)
- `pytest` (fails: ModuleNotFoundError: No module named 'cadquery')


------
https://chatgpt.com/codex/tasks/task_e_68acc053a79883339a64a29dfb6aa4a4