### PR TITLE
feat: add async DFM API

### DIFF
--- a/app.py
+++ b/app.py
@@ -37,7 +37,9 @@ from heatmap import generate_heatmap
 from material_recommender import recommend_materials_for_questionnaire
 import xkt_converter
 from tasks.conversion import generate_preview, generate_final
+from tasks.dfm import dfm_analysis
 from celery_app import celery, init_celery
+from celery.result import AsyncResult
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
 from log import log_action
@@ -1133,6 +1135,19 @@ def download_pdf(filename):
         logger.error(f"PDF download error: {str(e)}")
         return jsonify({'error': 'Erreur lors du téléchargement'}), 500
 
+
+@app.route('/download-csv/<filename>')
+def download_csv(filename):
+    """Download generated CSV report"""
+    try:
+        csv_path = os.path.join('reports', filename)
+        if not os.path.exists(csv_path):
+            return jsonify({'error': 'Fichier CSV non trouvé'}), 404
+        return send_file(csv_path, as_attachment=True, download_name=filename, mimetype='text/csv')
+    except Exception as e:
+        logger.error(f"CSV download error: {str(e)}")
+        return jsonify({'error': 'Erreur lors du téléchargement'}), 500
+
 @app.route('/download/zip/<conversion_id>')
 @login_required
 def download_zip(conversion_id):
@@ -1291,6 +1306,58 @@ def get_material_recommendations():
     except Exception as e:
         logger.error(f"Material recommendations error: {str(e)}")
         return jsonify({'error': f'Erreur lors de la génération des recommandations: {str(e)}'}), 500
+
+
+@app.route('/api/dfm/start', methods=['POST'])
+def dfm_start():
+    """Start asynchronous DFM analysis."""
+    data = request.get_json(silent=True) or {}
+    file_id = data.get('fileId')
+    material_profile = data.get('materialProfile')
+    if not file_id:
+        return jsonify({'error': 'missing_fileId'}), 400
+    task = dfm_analysis.delay(file_id, material_profile)
+    return jsonify({'jobId': task.id})
+
+
+@app.route('/api/dfm/status')
+def dfm_status():
+    """Return status of a DFM job."""
+    job_id = request.args.get('jobId')
+    if not job_id:
+        return jsonify({'error': 'missing_jobId'}), 400
+    res = AsyncResult(job_id, app=celery)
+    state_map = {
+        'PENDING': 'queued',
+        'STARTED': 'in_progress',
+        'PROGRESS': 'in_progress',
+        'SUCCESS': 'completed',
+        'FAILURE': 'failed',
+    }
+    response = {'status': state_map.get(res.state, 'queued')}
+    info = res.info if isinstance(res.info, dict) else {}
+    if 'progress' in info:
+        response['progress'] = info['progress']
+    return jsonify(response)
+
+
+@app.route('/api/dfm/results')
+def dfm_results():
+    """Fetch final DFM results."""
+    job_id = request.args.get('jobId')
+    if not job_id:
+        return jsonify({'error': 'missing_jobId'}), 400
+    reports_dir = app.config.get('REPORTS_FOLDER', 'reports')
+    json_path = os.path.join(reports_dir, f'dfm_result_{job_id}.json')
+    if not os.path.exists(json_path):
+        return jsonify({'error': 'not_found'}), 404
+    with open(json_path) as fh:
+        data = json.load(fh)
+    data['reportUrls'] = {
+        'pdf': url_for('download_pdf', filename=f'dfm_report_{job_id}.pdf'),
+        'csv': url_for('download_csv', filename=f'dfm_report_{job_id}.csv'),
+    }
+    return jsonify(data)
 
 @app.route('/api/dfm-summary')
 def dfm_summary():

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -1,5 +1,6 @@
 import os
 import json
+import csv
 import tempfile
 import shutil
 import dataclasses
@@ -13,6 +14,7 @@ from models import db, ModelJob, advance_model_job_status
 from celery_app import celery
 from dfm_analyzer import analyze_dfm
 from heatmap import generate_heatmap
+from pdf_generator import generate_dfm_pdf_report
 from storage.s3 import put_asset
 from observability.logging import get_logger
 from observability.metrics import dfm_seconds
@@ -69,5 +71,97 @@ def run_dfm(self, job_id: str) -> None:
             _notify_status(job)
             raise
         raise self.retry(exc=exc, countdown=2 ** self.request.retries)
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+@celery.task(bind=True, name="tasks.dfm_analysis")
+def dfm_analysis(self, file_id: str, material_profile: dict | None = None) -> None:
+    """Run DFM analysis and persist artifacts for API consumption."""
+    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{file_id}.step")
+    reports_dir = current_app.config.get("REPORTS_FOLDER", "reports")
+    os.makedirs(reports_dir, exist_ok=True)
+    job_id = self.request.id
+    tmp_dir = tempfile.mkdtemp(prefix="dfm_api_")
+    try:
+        report = analyze_dfm(step_path, material_profile.get("code") if isinstance(material_profile, dict) else "GENERIC")
+        report_dict = dataclasses.asdict(report)
+        issues = []
+        for wi in report_dict.get("wall_thickness_issues", []):
+            issues.append({
+                "title": "wall_thickness",
+                "description": f"Épaisseur {wi['thickness']:.2f}mm",
+                "severity": wi["severity"],
+                "recommendation": wi["issue_type"],
+            })
+        for gi in report_dict.get("geometry_issues", []):
+            issues.append({
+                "title": gi["issue_type"],
+                "description": gi["description"],
+                "severity": gi["severity"],
+                "recommendation": gi.get("recommendation", ""),
+            })
+
+        shape = cq.importers.importStep(step_path)
+        vertices, faces = shape.val().tessellate(0.5)
+        mesh = trimesh.Trimesh(vertices=vertices, faces=faces, process=False)
+        stl_path = os.path.join(tmp_dir, "mesh.stl")
+        mesh.export(stl_path)
+        raw_heat = generate_heatmap(stl_path)
+        max_index = max((h["face_index"] for h in raw_heat), default=-1)
+        values = [0.0] * (max_index + 1 if max_index >= 0 else 0)
+        for h in raw_heat:
+            values[h["face_index"]] = h["severity"]
+        heatmap = {
+            "type": "per-face",
+            "values": values,
+            "range": [min(values) if values else 0, max(values) if values else 0],
+            "legend": [],
+        }
+        result = {
+            "issues": issues,
+            "heatmap": heatmap,
+            "annotations": [],
+            "checklist": [],
+            "recommendations": {
+                "materials": [],
+                "process_notes": report_dict.get("recommendations", []),
+            },
+            "reportUrls": {},
+        }
+
+        json_path = os.path.join(reports_dir, f"dfm_result_{job_id}.json")
+        with open(json_path, "w") as fh:
+            json.dump(result, fh)
+
+        pdf_name = f"dfm_report_{job_id}.pdf"
+        pdf_path = os.path.join(reports_dir, pdf_name)
+        try:
+            generate_dfm_pdf_report(report_dict, step_path, pdf_path, os.path.basename(step_path))
+        except Exception:
+            logger.exception("pdf generation failed")
+
+        csv_name = f"dfm_report_{job_id}.csv"
+        csv_path = os.path.join(reports_dir, csv_name)
+        try:
+            with open(csv_path, "w", newline="") as csvfile:
+                writer = csv.writer(csvfile)
+                writer.writerow(["title", "description", "severity", "recommendation"])
+                for iss in issues:
+                    writer.writerow([
+                        iss.get("title"),
+                        iss.get("description"),
+                        iss.get("severity"),
+                        iss.get("recommendation", ""),
+                    ])
+        except Exception:
+            logger.exception("csv generation failed")
+
+        result["reportUrls"] = {
+            "pdf": f"/download-pdf/{pdf_name}",
+            "csv": f"/download-csv/{csv_name}",
+        }
+        with open(json_path, "w") as fh:
+            json.dump(result, fh)
     finally:
         shutil.rmtree(tmp_dir, ignore_errors=True)


### PR DESCRIPTION
## Summary
- add /api/dfm/start to launch Celery DFM analysis
- expose /api/dfm/status and /api/dfm/results for polling and data retrieval
- generate and serve DFM artifacts (heatmap, PDF, CSV)

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68acc176b4748333ab0db5c0d4acdc37