### PR TITLE
front: add axis picker and demould axis preview

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -4,6 +4,8 @@
  * Stocke fileId, materialProfile, demouldAxis
  */
 
+import AxisPicker from "./modules/AxisPicker.js";
+
 export const DFM_STATES = {
   IDLE: 'IDLE',
   MATERIAL_CONFIRMED: 'MATERIAL_CONFIRMED',
@@ -19,6 +21,8 @@ class DFMOrchestrator {
     this.fileId = null;
     this.materialProfile = null;
     this.demouldAxis = null;
+    this.axisPicker = null;
+    this._autoSuggestion = null;
   }
 
   setState(next) {
@@ -39,13 +43,61 @@ class DFMOrchestrator {
     panel = document.createElement('div');
     panel.id = 'dfmAxisPanel';
     panel.className = 'card mt-3';
-    panel.innerHTML = `
-      <div class="card-body d-flex justify-content-between align-items-center">
-        <div id="axisPreview" class="flex-grow-1">Prévisualisation axe (placeholder)</div>
-        <button id="confirmAxisBtn" class="btn btn-primary ms-3">Valider l'axe de démoulage</button>
-      </div>`;
+    panel.innerHTML = `<div class="card-body" id="axisPickerContainer"></div>`;
     const viewer = document.getElementById('viewer');
     viewer?.insertAdjacentElement('afterend', panel);
+
+    const container = panel.querySelector('#axisPickerContainer');
+    this.axisPicker = new AxisPicker(container);
+
+    this.axisPicker.addEventListener('preview', (e) => this.previewAxis(e.detail));
+    this.axisPicker.addEventListener('clear', () => window.viewerAdapter?.clearAxisPreview());
+    this.axisPicker.addEventListener('confirm', (e) => this.confirmAxis(e.detail));
+  }
+
+  async previewAxis(sel) {
+    if (sel.axis === 'AUTO') {
+      try {
+        const res = await fetch(`/api/dfm/axes/suggest?fileId=${this.fileId}`);
+        if (res.ok) {
+          const data = await res.json();
+          this._autoSuggestion = data;
+          window.viewerAdapter?.previewDemouldAxis(data);
+          if (data.axis && data.axis !== 'VECTOR') {
+            this.axisPicker.setValue({ axis: data.axis, direction: data.direction });
+          }
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    } else {
+      this._autoSuggestion = sel;
+      window.viewerAdapter?.previewDemouldAxis(sel);
+    }
+  }
+
+  confirmAxis(sel) {
+    const chosen = sel.axis === 'AUTO' && this._autoSuggestion ? this._autoSuggestion : sel;
+    this.setDemouldAxis(chosen);
+    document.getElementById('dfmAxisPanel')?.remove();
+    this.setState(DFM_STATES.RUNNING);
+    this.startDFM();
+  }
+
+  async startDFM() {
+    if (!this.fileId) return;
+    try {
+      await fetch(`/api/dfm/start?fileId=${this.fileId}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          material: this.materialProfile,
+          demouldAxis: this.demouldAxis
+        })
+      });
+    } catch (e) {
+      console.error(e);
+    }
   }
 }
 

--- a/static/js/modules/AxisPicker.js
+++ b/static/js/modules/AxisPicker.js
@@ -1,0 +1,74 @@
+export class AxisPicker extends EventTarget {
+  constructor(container) {
+    super();
+    this.el = container;
+    this.state = { axis: 'X', direction: 1 };
+    this._render();
+    this._bind();
+  }
+
+  _render() {
+    this.el.innerHTML = `
+      <div class="btn-group" role="group">
+        <input type="radio" class="btn-check" name="axis" id="axisX" value="X" autocomplete="off" checked>
+        <label class="btn btn-outline-secondary" for="axisX">X</label>
+        <input type="radio" class="btn-check" name="axis" id="axisY" value="Y" autocomplete="off">
+        <label class="btn btn-outline-secondary" for="axisY">Y</label>
+        <input type="radio" class="btn-check" name="axis" id="axisZ" value="Z" autocomplete="off">
+        <label class="btn btn-outline-secondary" for="axisZ">Z</label>
+        <input type="radio" class="btn-check" name="axis" id="axisAuto" value="AUTO" autocomplete="off">
+        <label class="btn btn-outline-secondary" for="axisAuto">Auto</label>
+      </div>
+      <div class="form-check form-switch d-inline-block ms-3">
+        <input class="form-check-input" type="checkbox" id="axisInvert">
+        <label class="form-check-label" for="axisInvert">Inverser le sens</label>
+      </div>
+      <div class="mt-2">
+        <button id="axisPreviewBtn" class="btn btn-sm btn-secondary">Aperçu</button>
+        <button id="axisClearBtn" class="btn btn-sm btn-outline-secondary ms-1">Effacer aperçu</button>
+        <button id="axisConfirmBtn" class="btn btn-sm btn-primary ms-3">Valider l'axe de démoulage</button>
+      </div>`;
+  }
+
+  _bind() {
+    this.el.querySelectorAll('input[name="axis"]').forEach(r => {
+      r.addEventListener('change', () => {
+        this.state.axis = r.value;
+        this.dispatchEvent(new CustomEvent('change', { detail: this.getValue() }));
+      });
+    });
+    this.el.querySelector('#axisInvert').addEventListener('change', (e) => {
+      this.state.direction = e.target.checked ? -1 : 1;
+      this.dispatchEvent(new CustomEvent('change', { detail: this.getValue() }));
+    });
+    this.el.querySelector('#axisPreviewBtn').addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('preview', { detail: this.getValue() }));
+    });
+    this.el.querySelector('#axisClearBtn').addEventListener('click', () => {
+      this.dispatchEvent(new Event('clear'));
+    });
+    this.el.querySelector('#axisConfirmBtn').addEventListener('click', () => {
+      this.dispatchEvent(new CustomEvent('confirm', { detail: this.getValue() }));
+    });
+  }
+
+  getValue() {
+    return { axis: this.state.axis, direction: this.state.direction };
+  }
+
+  setValue({ axis, direction }) {
+    if (axis) {
+      const input = this.el.querySelector(`input[name="axis"][value="${axis}"]`);
+      if (input) {
+        input.checked = true;
+        this.state.axis = axis;
+      }
+    }
+    if (typeof direction === 'number') {
+      this.el.querySelector('#axisInvert').checked = direction < 0;
+      this.state.direction = direction < 0 ? -1 : 1;
+    }
+  }
+}
+
+export default AxisPicker;

--- a/static/js/modules/DFMViewerAdapter.js
+++ b/static/js/modules/DFMViewerAdapter.js
@@ -72,6 +72,41 @@ export class DFMViewerAdapter {
     this._annotIds.forEach(id => this.annotations.removeAnnotation(id));
     this._annotIds = [];
   }
+
+  // Affiche une flèche simple représentant l'axe de démoulage
+  previewDemouldAxis({ axis = "X", direction = 1, vector = null } = {}) {
+    if (!this.viewer || !this.app.measure) return;
+    this.clearAxisPreview();
+
+    const aabb = this.viewer.scene.getAABB();
+    const cx = (aabb[0] + aabb[3]) / 2;
+    const cy = (aabb[1] + aabb[4]) / 2;
+    const cz = (aabb[2] + aabb[5]) / 2;
+    const size = Math.max(aabb[3] - aabb[0], aabb[4] - aabb[1], aabb[5] - aabb[2]);
+
+    let dir;
+    if (vector) {
+      const len = Math.hypot(vector[0], vector[1], vector[2]) || 1;
+      dir = [vector[0] / len, vector[1] / len, vector[2] / len];
+    } else {
+      dir = axis === "Y" ? [0, 1, 0] : axis === "Z" ? [0, 0, 1] : [1, 0, 0];
+    }
+    dir = dir.map((v) => v * (direction >= 0 ? 1 : -1));
+    const end = [cx + dir[0] * size, cy + dir[1] * size, cz + dir[2] * size];
+
+    this._axisMeasurement = this.app.measure.createMeasurement({
+      positions: [cx, cy, cz, ...end],
+      labelsShown: false
+    });
+  }
+
+  // Efface la prévisualisation d'axe
+  clearAxisPreview() {
+    if (this._axisMeasurement) {
+      this._axisMeasurement.destroy?.();
+      this._axisMeasurement = null;
+    }
+  }
 }
 
 export default DFMViewerAdapter;


### PR DESCRIPTION
## Summary
- add AxisPicker component for demould axis selection and preview
- extend DFMViewerAdapter with preview/clear APIs
- integrate axis panel into DFM orchestrator with auto suggestion and DFM start

## Testing
- `npm test` (fails: Error: no test specified)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68acce6f5e308333bcbf6d9f49a113ac