### PR TITLE
feat(dfm): add demould axis support

### DIFF
--- a/app.py
+++ b/app.py
@@ -1308,16 +1308,42 @@ def get_material_recommendations():
         return jsonify({'error': f'Erreur lors de la génération des recommandations: {str(e)}'}), 500
 
 
+@app.route('/api/dfm/axes/suggest')
+def dfm_axes_suggest():
+    """Suggest a demoulding axis for a given file."""
+    file_id = request.args.get('fileId')
+    if not file_id:
+        return jsonify({'error': 'missing_fileId'}), 400
+    step_path = os.path.join(app.config['UPLOAD_FOLDER'], f'{file_id}.step')
+    if not os.path.exists(step_path):
+        return jsonify({'error': 'not_found'}), 404
+    try:
+        shape = cq.importers.importStep(step_path)
+        bbox = shape.val().BoundingBox()
+        dims = {'X': bbox.xlen, 'Y': bbox.ylen, 'Z': bbox.zlen}
+        axis = max(dims, key=dims.get)
+        logger.info("Axis suggested", extra={"file_id": file_id, "axis": axis})
+        return jsonify({'axis': axis, 'direction': 1})
+    except Exception as e:
+        logger.exception("axis suggestion failed")
+        return jsonify({'error': 'axis_suggestion_failed', 'message': str(e)}), 500
+
 @app.route('/api/dfm/start', methods=['POST'])
 def dfm_start():
     """Start asynchronous DFM analysis."""
-    data = request.get_json(silent=True) or {}
-    file_id = data.get('fileId')
-    material_profile = data.get('materialProfile')
-    if not file_id:
-        return jsonify({'error': 'missing_fileId'}), 400
-    task = dfm_analysis.delay(file_id, material_profile)
-    return jsonify({'jobId': task.id})
+    try:
+        data = request.get_json(silent=True) or {}
+        file_id = data.get('fileId')
+        material_profile = data.get('materialProfile')
+        demould_axis = data.get('demouldAxis')
+        if not file_id:
+            return jsonify({'error': 'missing_fileId'}), 400
+        task = dfm_analysis.delay(file_id, material_profile, demould_axis)
+        logger.info("DFM job queued", extra={"file_id": file_id, "job_id": task.id})
+        return jsonify({'jobId': task.id})
+    except Exception as e:
+        logger.exception("dfm_start failed")
+        return jsonify({'error': 'dfm_start_failed', 'message': str(e)}), 500
 
 
 @app.route('/api/dfm/status')
@@ -1326,19 +1352,23 @@ def dfm_status():
     job_id = request.args.get('jobId')
     if not job_id:
         return jsonify({'error': 'missing_jobId'}), 400
-    res = AsyncResult(job_id, app=celery)
-    state_map = {
-        'PENDING': 'queued',
-        'STARTED': 'in_progress',
-        'PROGRESS': 'in_progress',
-        'SUCCESS': 'completed',
-        'FAILURE': 'failed',
-    }
-    response = {'status': state_map.get(res.state, 'queued')}
-    info = res.info if isinstance(res.info, dict) else {}
-    if 'progress' in info:
-        response['progress'] = info['progress']
-    return jsonify(response)
+    try:
+        res = AsyncResult(job_id, app=celery)
+        state_map = {
+            'PENDING': 'queued',
+            'STARTED': 'in_progress',
+            'PROGRESS': 'in_progress',
+            'SUCCESS': 'completed',
+            'FAILURE': 'failed',
+        }
+        response = {'status': state_map.get(res.state, 'queued')}
+        info = res.info if isinstance(res.info, dict) else {}
+        if 'progress' in info:
+            response['progress'] = info['progress']
+        return jsonify(response)
+    except Exception as e:
+        logger.exception("dfm_status failed")
+        return jsonify({'error': 'dfm_status_failed', 'message': str(e)}), 500
 
 
 @app.route('/api/dfm/results')
@@ -1351,13 +1381,17 @@ def dfm_results():
     json_path = os.path.join(reports_dir, f'dfm_result_{job_id}.json')
     if not os.path.exists(json_path):
         return jsonify({'error': 'not_found'}), 404
-    with open(json_path) as fh:
-        data = json.load(fh)
-    data['reportUrls'] = {
-        'pdf': url_for('download_pdf', filename=f'dfm_report_{job_id}.pdf'),
-        'csv': url_for('download_csv', filename=f'dfm_report_{job_id}.csv'),
-    }
-    return jsonify(data)
+    try:
+        with open(json_path) as fh:
+            data = json.load(fh)
+        data['reportUrls'] = {
+            'pdf': url_for('download_pdf', filename=f'dfm_report_{job_id}.pdf'),
+            'csv': url_for('download_csv', filename=f'dfm_report_{job_id}.csv'),
+        }
+        return jsonify(data)
+    except Exception as e:
+        logger.exception("dfm_results failed")
+        return jsonify({'error': 'dfm_results_failed', 'message': str(e)}), 500
 
 @app.route('/api/dfm-summary')
 def dfm_summary():

--- a/dfm_analyzer.py
+++ b/dfm_analyzer.py
@@ -88,29 +88,24 @@ class DFMAnalyzer:
         self.thickness_tolerance_percentage = 0.15  # 15% de tolérance pour zones isolées
         self.minimum_significant_area = 10.0  # mm² - aire minimale pour considérer un défaut
         
-    def analyze_step_file(self, step_file_path: str, demolding_axis: str = 'z', material_type: str = None) -> DFMReport:
-        """
-        Complete DFM analysis of a STEP file
-        """
+    def analyze_step_file(self, step_file_path: str, demould_axis: dict | str = 'z', material_type: str = None) -> DFMReport:
+        """Complete DFM analysis of a STEP file."""
         try:
-            # Import the STEP file
+            axis_info = self._normalize_axis(demould_axis)
             workplane = cq.importers.importStep(step_file_path)
-            
-            # Perform all analyses
-            dimensions = self._analyze_dimensions(workplane)
+
+            dimensions = self._analyze_dimensions(workplane, axis_info['axis'])
             wall_issues = self._analyze_wall_thickness(workplane)
-            geometry_issues = self._analyze_geometry_issues(workplane)
-            
-            # Calculate overall rating
+            geometry_issues = self._analyze_geometry_issues(workplane, axis_info)
+
             overall_score, moldability_rating = self._calculate_overall_rating(
                 dimensions, wall_issues, geometry_issues
             )
-            
-            # Generate recommendations
+
             recommendations = self._generate_recommendations(
                 dimensions, wall_issues, geometry_issues
             )
-            
+
             return DFMReport(
                 dimensions=dimensions,
                 wall_thickness_issues=wall_issues,
@@ -119,12 +114,25 @@ class DFMAnalyzer:
                 moldability_rating=moldability_rating,
                 recommendations=recommendations
             )
-            
+
         except Exception as e:
             print(f"Error analyzing STEP file: {e}")
             import traceback
             print(f"Traceback: {traceback.format_exc()}")
             return self._create_error_report()
+
+    def _normalize_axis(self, demould_axis):
+        axis = 'z'
+        direction = 1
+        vec = None
+        if isinstance(demould_axis, dict):
+            axis = demould_axis.get('axis', 'Z').lower()
+            direction = demould_axis.get('direction', 1) or 1
+            if axis == 'vector':
+                vec = demould_axis.get('vector') or [0, 0, 1]
+        elif isinstance(demould_axis, str):
+            axis = demould_axis.lower()
+        return {'axis': axis, 'direction': direction, 'vector': vec}
     
     def _analyze_dimensions(self, workplane, demolding_axis: str = 'z') -> DimensionAnalysis:
         """Analyze global dimensions and calculate maximum wall thickness"""
@@ -490,24 +498,23 @@ class DFMAnalyzer:
         
         return issues
     
-    def _analyze_geometry_issues(self, workplane, demolding_axis: str = 'z') -> List[GeometryIssue]:
+    def _analyze_geometry_issues(self, workplane, axis_info: dict | str = 'z') -> List[GeometryIssue]:
         """Analyze various geometry issues for injection molding"""
         issues = []
-        
+
         try:
+            if isinstance(axis_info, str):
+                axis_info = self._normalize_axis(axis_info)
             # Quick check if this is a very large model - use simplified analysis
             try:
                 faces = workplane.faces().vals()
-                if len(faces) > 1000:  # Large model - use simplified analysis
+                if len(faces) > 1000:
                     print(f"Large model detected ({len(faces)} faces), using simplified geometry analysis")
-                    return self._analyze_geometry_issues_simplified(workplane, demolding_axis)
+                    return self._analyze_geometry_issues_simplified(workplane, axis_info)
             except:
-                # If we can't count faces, assume it's complex and use simplified method
                 print("Could not count faces, using simplified geometry analysis")
-                return self._analyze_geometry_issues_simplified(workplane, demolding_axis)
-            
-            # Standard analysis for smaller models
-            # Check overall height
+                return self._analyze_geometry_issues_simplified(workplane, axis_info)
+
             bbox = workplane.val().BoundingBox()
             if bbox.zlen > self.max_height:
                 issues.append(GeometryIssue(
@@ -530,9 +537,8 @@ class DFMAnalyzer:
                 ))
             
             # Check for draft angles
-            perpendicular_faces = self._find_perpendicular_faces(workplane, demolding_axis)
+            perpendicular_faces = self._find_perpendicular_faces(workplane, axis_info)
             for face_center in perpendicular_faces:
-                axis_name = {'x': 'X', 'y': 'Y', 'z': 'Z'}[demolding_axis]
                 issues.append(GeometryIssue(
                     location=face_center,
                     issue_type="missing_draft",
@@ -557,16 +563,18 @@ class DFMAnalyzer:
         
         return issues
     
-    def _analyze_geometry_issues_simplified(self, workplane, demolding_axis: str = 'z') -> List[GeometryIssue]:
+    def _analyze_geometry_issues_simplified(self, workplane, axis_info: dict | str = 'z') -> List[GeometryIssue]:
         """Simplified geometry analysis for large models to avoid timeouts"""
         issues = []
-        
+
         try:
-            # Only check basic overall dimensions (fast operation)
+            if isinstance(axis_info, str):
+                axis_info = self._normalize_axis(axis_info)
             bbox = workplane.val().BoundingBox()
-            
-            # Check overall height based on demolding axis
-            axis_length = bbox.zlen if demolding_axis == 'z' else (bbox.ylen if demolding_axis == 'y' else bbox.xlen)
+
+            axis_length = bbox.zlen if axis_info['axis'] == 'z' else (
+                bbox.ylen if axis_info['axis'] == 'y' else bbox.xlen
+            )
             
             if axis_length > self.max_height:
                 center_location = (bbox.center.x, bbox.center.y, bbox.center.z)
@@ -779,16 +787,22 @@ class DFMAnalyzer:
 
         return sharp_edges
     
-    def _find_perpendicular_faces(self, workplane, demolding_axis: str) -> List[Tuple[float, float, float]]:
+    def _find_perpendicular_faces(self, workplane, axis_info: dict | str) -> List[Tuple[float, float, float]]:
         """Find planar faces nearly parallel to the demolding direction"""
         perpendicular_faces = []
 
         try:
-            axis_vec = {
-                'x': cq.Vector(1, 0, 0),
-                'y': cq.Vector(0, 1, 0),
-                'z': cq.Vector(0, 0, 1)
-            }[demolding_axis]
+            if isinstance(axis_info, str):
+                axis_info = self._normalize_axis(axis_info)
+            if axis_info['vector']:
+                v = axis_info['vector']
+                axis_vec = cq.Vector(v[0], v[1], v[2]).normalized()
+            else:
+                axis_vec = {
+                    'x': cq.Vector(1, 0, 0),
+                    'y': cq.Vector(0, 1, 0),
+                    'z': cq.Vector(0, 0, 1)
+                }[axis_info['axis']] * axis_info['direction']
 
             for face in workplane.val().Faces():
                 try:
@@ -1130,17 +1144,10 @@ class DFMAnalyzer:
             recommendations=["Impossible d'analyser le fichier - vérifier le format STEP"]
         )
 
-def analyze_dfm(step_file_path: str, demolding_axis: str = 'z', material_type: str = 'GENERIC') -> DFMReport:
-    """
-    Convenience function to analyze a STEP file with intelligent material-aware analysis
-    
-    Args:
-        step_file_path: Path to the STEP file
-        demolding_axis: Axis of demolding ('x', 'y', or 'z')
-        material_type: Type of plastic material (PP, PE, ABS, PC, PA66, POM, PS, GENERIC)
-    """
+def analyze_dfm(step_file_path: str, demould_axis: dict | str = 'z', material_type: str = 'GENERIC') -> DFMReport:
+    """Convenience function to analyze a STEP file."""
     analyzer = DFMAnalyzer(material_type=material_type)
-    return analyzer.analyze_step_file(step_file_path, demolding_axis, material_type)
+    return analyzer.analyze_step_file(step_file_path, demould_axis, material_type)
 
 
 def compute_projected_area(mesh, axis='z'):

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -76,7 +76,7 @@ def run_dfm(self, job_id: str) -> None:
 
 
 @celery.task(bind=True, name="tasks.dfm_analysis")
-def dfm_analysis(self, file_id: str, material_profile: dict | None = None) -> None:
+def dfm_analysis(self, file_id: str, material_profile: dict | None = None, demould_axis: dict | None = None) -> None:
     """Run DFM analysis and persist artifacts for API consumption."""
     step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{file_id}.step")
     reports_dir = current_app.config.get("REPORTS_FOLDER", "reports")
@@ -84,7 +84,8 @@ def dfm_analysis(self, file_id: str, material_profile: dict | None = None) -> No
     job_id = self.request.id
     tmp_dir = tempfile.mkdtemp(prefix="dfm_api_")
     try:
-        report = analyze_dfm(step_path, material_profile.get("code") if isinstance(material_profile, dict) else "GENERIC")
+        material_code = material_profile.get("code") if isinstance(material_profile, dict) else "GENERIC"
+        report = analyze_dfm(step_path, demould_axis or 'z', material_code)
         report_dict = dataclasses.asdict(report)
         issues = []
         for wi in report_dict.get("wall_thickness_issues", []):
@@ -128,6 +129,7 @@ def dfm_analysis(self, file_id: str, material_profile: dict | None = None) -> No
                 "process_notes": report_dict.get("recommendations", []),
             },
             "reportUrls": {},
+            "demouldAxis": demould_axis,
         }
 
         json_path = os.path.join(reports_dir, f"dfm_result_{job_id}.json")


### PR DESCRIPTION
## Summary
- add `/api/dfm/axes/suggest` endpoint
- handle `demouldAxis` in async DFM analysis
- integrate demould axis in geometry checks and task outputs

## Testing
- `pytest` *(fails: No module named 'requests', 'cadquery', 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68acd13072148333a4ec8e465c7f1fbd