### PR TITLE
feat(dfm): orchestrate async analysis flow

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -80,24 +80,184 @@ class DFMOrchestrator {
     const chosen = sel.axis === 'AUTO' && this._autoSuggestion ? this._autoSuggestion : sel;
     this.setDemouldAxis(chosen);
     document.getElementById('dfmAxisPanel')?.remove();
-    this.setState(DFM_STATES.RUNNING);
-    this.startDFM();
+    this.startAnalysis();
   }
 
-  async startDFM() {
-    if (!this.fileId) return;
+  // --- 1) startAnalysis -----------------------------------------------------
+  async startAnalysis({ fileId = this.fileId, materialProfile = this.materialProfile, demouldAxis = this.demouldAxis } = {}) {
+    if (!fileId) return;
+    this.setState(DFM_STATES.RUNNING);
+    this._renderLoading();
     try {
-      await fetch(`/api/dfm/start?fileId=${this.fileId}`, {
+      const res = await fetch('/api/dfm/start', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          material: this.materialProfile,
-          demouldAxis: this.demouldAxis
-        })
+        body: JSON.stringify({ fileId, materialProfile, demouldAxis })
       });
+      if (!res.ok) throw new Error('start_failed');
+      const data = await res.json();
+      this.pollStatus(data.jobId);
     } catch (e) {
       console.error(e);
+      this.handleError('Démarrage analyse impossible');
     }
+  }
+
+  // --- 2) pollStatus -------------------------------------------------------
+  async pollStatus(jobId) {
+    try {
+      const res = await fetch(`/api/dfm/status?jobId=${jobId}`);
+      if (!res.ok) throw new Error('status_failed');
+      const data = await res.json();
+      if (data.progress !== undefined) {
+        const bar = document.getElementById('dfmProgressBar');
+        if (bar) bar.style.width = `${data.progress}%`;
+      }
+      if (data.status === 'completed') {
+        this.fetchResults(jobId);
+      } else if (data.status === 'failed') {
+        this.handleError('Analyse échouée');
+      } else {
+        setTimeout(() => this.pollStatus(jobId), 2500);
+      }
+    } catch (e) {
+      console.error(e);
+      this.handleError('Erreur de suivi d’analyse');
+    }
+  }
+
+  // --- 3) fetchResults -----------------------------------------------------
+  async fetchResults(jobId) {
+    try {
+      const res = await fetch(`/api/dfm/results?jobId=${jobId}`);
+      if (!res.ok) throw new Error('results_failed');
+      const data = await res.json();
+      this.renderResults(data);
+    } catch (e) {
+      console.error(e);
+      this.handleError('Récupération résultats impossible');
+    }
+  }
+
+  // --- 4) renderResults ----------------------------------------------------
+  renderResults(results = {}) {
+    this.setState(DFM_STATES.RESULTS);
+    const section = document.getElementById('dfmResultsSection');
+    section.style.display = 'block';
+    const panel = document.getElementById('dfmAnalysisPanel');
+    panel.innerHTML = '';
+
+    // Table des issues ------------------------------------------------------
+    if (Array.isArray(results.issues) && results.issues.length) {
+      const table = document.createElement('table');
+      table.className = 'table table-sm';
+      table.innerHTML = `<thead><tr>
+        <th data-sort="severity">Severité</th>
+        <th data-sort="type">Type</th>
+        <th>Description</th></tr></thead>`;
+      const tbody = document.createElement('tbody');
+      results.issues.forEach(issue => {
+        const tr = document.createElement('tr');
+        tr.dataset.severity = issue.severity || '';
+        tr.dataset.type = issue.type || '';
+        tr.innerHTML = `<td>${issue.severity || ''}</td><td>${issue.type || ''}</td><td>${issue.message || ''}</td>`;
+        tbody.appendChild(tr);
+      });
+      table.appendChild(tbody);
+      this._makeSortable(table);
+      panel.appendChild(table);
+    } else {
+      panel.textContent = 'Aucune anomalie détectée';
+    }
+
+    // Checklist -------------------------------------------------------------
+    const checklistWrap = document.getElementById('moldingChecklist');
+    const checklistItems = document.getElementById('checklistItems');
+    checklistItems.innerHTML = '';
+    if (Array.isArray(results.checklist) && results.checklist.length) {
+      checklistWrap.style.display = 'block';
+      results.checklist.forEach(it => {
+        const div = document.createElement('div');
+        const cls = it.status === 'pass' ? 'success' : it.status === 'warn' ? 'warning' : 'danger';
+        div.className = `list-group-item list-group-item-${cls}`;
+        div.textContent = it.label || '';
+        checklistItems.appendChild(div);
+      });
+    }
+
+    // Recommandations matiere ----------------------------------------------
+    const recWrap = document.getElementById('materialRecommendations');
+    const recList = document.getElementById('recommendationItems');
+    recList.innerHTML = '';
+    if (Array.isArray(results.materialRecommendations) && results.materialRecommendations.length) {
+      recWrap.style.display = 'block';
+      results.materialRecommendations.forEach(r => {
+        const li = document.createElement('li');
+        li.className = 'list-group-item';
+        li.textContent = r;
+        recList.appendChild(li);
+      });
+    }
+
+    // Liens rapports -------------------------------------------------------
+    if (results.reportUrls) {
+      const pdf = document.getElementById('generatePdfBtn');
+      const csv = document.getElementById('downloadCsvBtn');
+      pdf.style.display = 'inline-block';
+      csv.style.display = 'inline-block';
+      pdf.href = results.reportUrls.pdf;
+      csv.href = results.reportUrls.csv;
+    }
+
+    // Heatmap / annotations -------------------------------------------------
+    window.viewerAdapter?.applyHeatmap(results.heatmap);
+    window.viewerAdapter?.addAnnotations(results.annotations);
+  }
+
+  // --- 5) Error management -------------------------------------------------
+  handleError(message) {
+    this.setState(DFM_STATES.ERROR);
+    const section = document.getElementById('dfmResultsSection');
+    section.style.display = 'block';
+    const panel = document.getElementById('dfmAnalysisPanel');
+    panel.innerHTML = `<div class="alert alert-danger">${message} <a href="#" id="retryDFM" class="alert-link">Relancer</a></div>`;
+    document.getElementById('retryDFM')?.addEventListener('click', (e) => {
+      e.preventDefault();
+      this.setState(DFM_STATES.AXIS_PICK);
+    });
+  }
+
+  // Utilitaires -------------------------------------------------------------
+  _renderLoading() {
+    const section = document.getElementById('dfmResultsSection');
+    section.style.display = 'block';
+    const panel = document.getElementById('dfmAnalysisPanel');
+    panel.innerHTML = `<div id="dfmLoading" class="text-center my-3">
+      <div class="spinner-border" role="status"></div>
+      <div id="dfmProgressText" class="mt-2">Analyse DFM en cours...</div>
+      <div class="progress mt-2">
+        <div id="dfmProgressBar" class="progress-bar progress-bar-striped" style="width:0%"></div>
+      </div>
+    </div>`;
+  }
+
+  _makeSortable(table) {
+    const headers = table.querySelectorAll('th[data-sort]');
+    headers.forEach(h => {
+      h.style.cursor = 'pointer';
+      h.addEventListener('click', () => {
+        const key = h.dataset.sort;
+        const tbody = table.tBodies[0];
+        const rows = Array.from(tbody.querySelectorAll('tr'));
+        const asc = h.classList.toggle('asc');
+        rows.sort((a, b) => {
+          const av = a.dataset[key] || '';
+          const bv = b.dataset[key] || '';
+          return asc ? av.localeCompare(bv) : bv.localeCompare(av);
+        });
+        rows.forEach(r => tbody.appendChild(r));
+      });
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- Orchestrate DFM analysis lifecycle (start, poll, fetch, render)
- Display issues table, checklist, material suggestions, and reports
- Handle errors with retry and feed viewer with heatmap/annotations

## Testing
- `npm test` (fails: Error: no test specified)
- `PYTHONPATH=$PWD pytest` (fails: Can't create UniqueConstraint on table 'o_auth')

------
https://chatgpt.com/codex/tasks/task_e_68acd5b08bf48333be3ca2ddcea8f7b1