### PR TITLE
feat: sauvegarde du profil matière

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -94,7 +94,8 @@ class DFMOrchestrator {
     if (!fileId || !materialProfile) {
       console.log({ fileLoaded: state.fileLoaded, materialProfile: state.materialProfile });
       console.trace('DFM blocked here');
-      alert('Fichier ou profil matière manquant');
+      console.error("DFM blocked", { fileLoaded: state?.fileLoaded, materialProfile: !!state?.materialProfile });
+      if (window.showToast) showToast("Veuillez charger un fichier et sélectionner un profil matière avant d’analyser.");
       this.handleError('Paramètres manquants');
       return;
     }

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -169,3 +169,75 @@ export class XeokitModelViewer extends EventTarget {
         }
     }
 }
+
+// ==== CADLYTICS: MATERIAL PROFILE BLOCK - BEGIN ====
+if (typeof collectMaterialForm !== 'function') {
+  window.collectMaterialForm = function collectMaterialForm() {
+    const form = document.getElementById('materialForm') || document.querySelector('[data-form="material"]');
+    // Lis les champs de manière défensive
+    const getVal = sel => (form && form.querySelector(sel) ? form.querySelector(sel).value : null);
+    const getChecks = sel => Array.from(form ? form.querySelectorAll(sel) : []).filter(i => i.checked).map(i => i.value);
+    return {
+      family: getVal('[name="materialFamily"]'),
+      rigidity: getVal('[name="rigidity"]'),
+      color: getVal('[name="color"]'),
+      constraints: getChecks('[name="constraints"]'),
+    };
+  };
+}
+(function ensureMaterialConfirmHandler(){
+  const btn = document.getElementById('materialModalConfirm') || document.querySelector('[data-action="material-confirm"]');
+  if (!btn || btn.dataset.cadlyticsBound === '1') return;
+  btn.addEventListener('click', () => {
+    window.state = window.state || {};
+    window.state.materialProfile = window.collectMaterialForm();
+    document.dispatchEvent(new CustomEvent('material:confirmed', { detail: window.state.materialProfile }));
+  });
+  btn.dataset.cadlyticsBound = '1';
+})();
+// ==== CADLYTICS: MATERIAL PROFILE BLOCK - END ====
+
+// ==== CADLYTICS: DFM CHAIN BLOCK - BEGIN ====
+(function bindDFMAfterMaterial(){
+  if (window.__cadlyticsDFMChained) return;
+  window.__cadlyticsDFMChained = true;
+  document.addEventListener('material:confirmed', () => {
+    window.state = window.state || {};
+    if (window.state.fileLoaded && window.state.materialProfile) {
+      if (typeof window.runDFM === 'function') {
+        window.runDFM();
+      } else {
+        console.warn('runDFM() introuvable. Vérifie son export global.');
+      }
+    } else {
+      console.warn('DFM non lancée (pré-requis manquants):', {
+        fileLoaded: window.state.fileLoaded,
+        materialProfile: !!window.state.materialProfile
+      });
+    }
+  });
+})();
+// ==== CADLYTICS: DFM CHAIN BLOCK - END ====
+
+// ==== CADLYTICS: TOAST UTIL - BEGIN ====
+(function ensureToast(){
+  if (window.showToast) return;
+  const ensureStyle = () => {
+    if (document.getElementById('cadlytics-toast-style')) return;
+    const css = document.createElement('style');
+    css.id = 'cadlytics-toast-style';
+    css.textContent = `
+    .cadlytics-toast{position:fixed;left:50%;bottom:24px;transform:translateX(-50%);padding:12px 16px;border-radius:8px;background:#333;color:#fff;box-shadow:0 6px 20px rgba(0,0,0,.2);opacity:.96;z-index:9999;font:14px/1.3 system-ui,Segoe UI,Roboto}
+    `;
+    document.head.appendChild(css);
+  };
+  window.showToast = function(message){
+    ensureStyle();
+    const el = document.createElement('div');
+    el.className = 'cadlytics-toast';
+    el.textContent = message;
+    document.body.appendChild(el);
+    setTimeout(()=>{ el.remove(); }, 3000);
+  };
+})();
+// ==== CADLYTICS: TOAST UTIL - END ====


### PR DESCRIPTION
## Summary
- sauvegarde le profil matière via collectMaterialForm et listener dédié
- lance runDFM après confirmation du profil matière
- remplace l'alerte bloquante par un toast non bloquant

## Testing
- `npm test` (fails: Error: no test specified)
- `PYTHONPATH=. pytest` (fails: ModuleNotFoundError: No module named 'requests')

------
https://chatgpt.com/codex/tasks/task_e_68ae17fd860c83339392cf82481bb7d6