### PR TITLE
Expose file ID after upload and viewer load

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -40,7 +40,11 @@ class DFMOrchestrator {
     if (next === DFM_STATES.AXIS_PICK) this.renderAxisPanel();
   }
 
-  setFileId(id){ this.fileId = id || null; }
+  setFileId(id){
+    this.fileId = id || null;
+    const hidden = document.getElementById('fileId');
+    if (hidden && hidden.type === 'hidden') hidden.value = this.fileId || '';
+  }
   setMaterialProfile(p){ this.materialProfile = p || null; }
   setDemouldAxis(a){ this.demouldAxis = a || null; }
 
@@ -69,7 +73,11 @@ class DFMOrchestrator {
     id = any && pickData(any);
     if (id) return id;
 
-    // 5) URL : /view/<id> ou /result/<id> ou ?fileId=…&jobId=…
+    // 5) champ caché #fileId
+    const hidden = document.getElementById('fileId');
+    if (hidden && hidden.type === 'hidden' && hidden.value) return hidden.value;
+
+    // 6) URL : /view/<id> ou /result/<id> ou ?fileId=…&jobId=…
     const path = location.pathname;
     let m = path.match(/\/(view|result)\/([^/?#]+)/i);
     if (m && m[2]) return m[2];

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -33,12 +33,16 @@ export class XeokitModelViewer extends EventTarget {
     window.CADLYTICS.current = { jobId: id, modelId: id };
     window.viewerAdapter = window.viewerAdapter || {};
     window.viewerAdapter.current = { jobId: id, modelId: id };
+    const hidden = document.getElementById('fileId');
+    if (hidden && hidden.type === 'hidden') hidden.value = id;
     window.dispatchEvent(new CustomEvent('dfm:fileReady', { detail: { fileId: id }}));
+    window.state = window.state || {};
+    window.state.fileLoaded = true;
     console.debug('[VIEWER] fileId exposé:', id);
   }
 
   // --- chargement ---------------------------------------------------------
-  async load(url, { quality = "preview" } = {}) {
+  async load(url, { quality = "preview", apiId } = {}) {
     const cam = this.viewer.camera.getState();
     if (this.model) {
       this.model.destroy();
@@ -56,6 +60,10 @@ export class XeokitModelViewer extends EventTarget {
       }
     }
     this.currentQuality = quality;
+    if (apiId) {
+      this.apiId = apiId;
+      this._exposeFileId(apiId);
+    }
     if (this.heatmapActive && this.colorBuffer) {
       this._applyColors(this.colorBuffer);
     }

--- a/static/js/tus-upload.js
+++ b/static/js/tus-upload.js
@@ -91,6 +91,11 @@
     // 4) optionnel : accessible pour d’autres modules
     window.viewerAdapter = window.viewerAdapter || {};
     window.viewerAdapter.current = { jobId: id, modelId: id };
+    // 5) remplit un champ caché si présent
+    const hidden = document.getElementById('fileId');
+    if (hidden && hidden.type === 'hidden') hidden.value = id;
+    window.state = window.state || {};
+    window.state.fileLoaded = true;
     console.debug('[UPLOAD] fileId exposé:', id);
   }
 
@@ -112,7 +117,9 @@
       // Récupère l’ID quel que soit le nom renvoyé par l’API
       const id =
         data?.jobId ||
+        data?.job_id ||
         data?.modelId ||
+        data?.model_id ||
         data?.id ||
         data?.conversion_id ||
         data?.result?.id;


### PR DESCRIPTION
## Summary
- expose file ID when viewer loads with an apiId and flag file as ready
- mark upload success by setting global fileLoaded state
- resolve file ID from hidden #fileId input and keep it updated

## Testing
- `npm run build`
- `PYTHONPATH=$PWD pytest` *(fails: ModuleNotFoundError: requests, cadquery, flask)*


------
https://chatgpt.com/codex/tasks/task_e_68b691fbe2a08333b80cadea9f943a13