### PR TITLE
feat: robust celery init

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,28 @@ Les fichiers téléchargés (`uploads/`) et convertis (`converted/`) sont conser
 
 ## Lancer les services
 
+Définir les variables d'environnement suivantes **à l'identique** pour le web
+et pour le worker :
+
 ```
-redis-server --daemonize yes
-CELERY_BROKER_URL=redis://localhost:6379/0 ./start_worker.sh
-CELERY_BROKER_URL=redis://localhost:6379/0 ./start_beat.sh
-CELERY_BROKER_URL=redis://localhost:6379/0 gunicorn app:app --timeout 600
+export REDIS_URL="redis://:PASSWORD@HOST:PORT/0"  # ou CELERY_BROKER_URL
+export CELERY_RESULT_BACKEND="$REDIS_URL"
 ```
+
+Lancer l'application Flask :
+
+```
+gunicorn web:app --timeout 600
+```
+
+Lancer le worker Celery :
+
+```
+celery -A celery_app.celery worker -l info -P solo
+```
+
+Sans URLs fournies, l'application bascule en mode dégradé (`memory://` +
+`rpc://`).
 
 ## Variables d'environnement importantes
 

--- a/celery_app.py
+++ b/celery_app.py
@@ -1,14 +1,54 @@
+"""Initialisation de Celery pour Cadlytics.
+
+Variables d'environnement obligatoires :
+    - ``REDIS_URL`` ou ``CELERY_BROKER_URL`` : URL du broker (ex. ``redis://:pass@host:6379/0``)
+    - ``CELERY_RESULT_BACKEND`` : URL du backend (peut être identique au broker)
+
+Commande worker :
+    ``celery -A celery_app.celery worker -l info -P solo``
+
+Le dyno web et le worker doivent partager **exactement** les mêmes variables
+d'environnement. Sans URL fournie, l'application bascule en mode dégradé avec
+un broker ``memory://`` et un backend ``rpc://``.
+"""
+
 import os
 from celery import Celery
+from flask import current_app
+from kombu.exceptions import OperationalError as KombuOperationalError
+from redis.exceptions import ConnectionError as RedisConnectionError
+
+try:
+    from observability.metrics import celery_ready as celery_ready_metric
+except Exception:  # pragma: no cover - metrics optional
+    celery_ready_metric = None
+
+_last_ready = None
 
 celery = Celery("cadlytics", include=["tasks.conversion", "tasks.dfm"])
 
 
 def init_celery(app):
-    broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
-    backend = os.getenv("CELERY_BACKEND_URL", broker)
+    broker = os.getenv("CELERY_BROKER_URL") or os.getenv("REDIS_URL")
+    backend = os.getenv("CELERY_RESULT_BACKEND") or broker
+
+    celery_enabled = bool(broker)
+    if not celery_enabled:
+        broker = "memory://"
+        backend = "rpc://"
+
+    app.config.update(
+        CELERY_ENABLED=celery_enabled,
+        CELERY_BROKER_URL=broker if celery_enabled else None,
+        CELERY_RESULT_BACKEND=backend if celery_enabled else None,
+    )
+
     celery.conf.update(broker_url=broker, result_backend=backend)
     celery.conf.update(app.config)
+    celery.conf.update(
+        broker_transport_options={"socket_timeout": 2},
+        result_backend_transport_options={"socket_timeout": 2},
+    )
 
     class ContextTask(celery.Task):
         def __call__(self, *args, **kwargs):
@@ -16,4 +56,33 @@ def init_celery(app):
                 return super().__call__(*args, **kwargs)
 
     celery.Task = ContextTask
+    app.celery = celery
     return celery
+
+
+def is_celery_ready() -> bool:
+    app = current_app
+    ready = False
+    if app.config.get("CELERY_ENABLED"):
+        celery_app = getattr(app, "celery", None)
+        if celery_app:
+            try:
+                ready = bool(celery_app.control.ping(timeout=1))
+            except (RedisConnectionError, KombuOperationalError):
+                ready = False
+
+    global _last_ready
+    if _last_ready is not None and ready != _last_ready:
+        if ready:
+            app.logger.info("Celery broker reachable again")
+        else:
+            app.logger.warning("Celery broker became unreachable")
+    _last_ready = ready
+
+    if celery_ready_metric is not None:
+        try:
+            celery_ready_metric.set(1 if ready else 0)
+        except Exception:
+            pass
+
+    return ready

--- a/observability/__init__.py
+++ b/observability/__init__.py
@@ -1,9 +1,10 @@
 from .logging import setup_logging, get_logger
-from .metrics import setup_metrics, record_cache_hit
+from .metrics import setup_metrics, record_cache_hit, celery_ready
 
 __all__ = [
     "setup_logging",
     "get_logger",
     "setup_metrics",
     "record_cache_hit",
+    "celery_ready",
 ]

--- a/observability/metrics.py
+++ b/observability/metrics.py
@@ -1,4 +1,3 @@
-import time
 from flask import Response
 from prometheus_client import (
     Histogram,
@@ -20,6 +19,8 @@ ttfv_seconds = Histogram("ttfv_seconds", "Time from upload to preview ready")
 # Size gauges
 preview_size_bytes = Gauge("preview_size_bytes", "Preview file size in bytes")
 final_size_bytes = Gauge("final_size_bytes", "Final file size in bytes")
+# Celery readiness
+celery_ready = Gauge("celery_ready", "Celery availability (1=up,0=down)")
 # Cache ratio
 cache_hit_ratio = Gauge("cache_hit_ratio", "Cache hit ratio")
 _hits = 0

--- a/start_worker.sh
+++ b/start_worker.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 # Script de lancement du worker Celery pour Cadlytics
-export CELERY_BROKER_URL="${CELERY_BROKER_URL:-redis://localhost:6379/0}"
-exec celery -A worker.celery worker --loglevel=info
+exec celery -A celery_app.celery worker -l info -P solo

--- a/web.py
+++ b/web.py
@@ -13,6 +13,7 @@ from flask import (
     redirect,
     url_for,
     flash,
+    current_app,
 )
 from flask_cors import CORS
 from flask_migrate import Migrate
@@ -25,6 +26,7 @@ import time
 import shutil
 import tempfile
 import subprocess
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from OCP.STEPControl import STEPControl_Reader
 from OCP.StlAPI import StlAPI_Writer
 from OCP.Interface import Interface_Static
@@ -38,7 +40,7 @@ from material_recommender import recommend_materials_for_questionnaire
 import xkt_converter
 from tasks.conversion import generate_preview, generate_final
 from tasks.dfm import dfm_analysis
-from celery_app import celery, init_celery
+from celery_app import celery, init_celery, is_celery_ready
 from celery.result import AsyncResult
 from flask_login import LoginManager, login_required, current_user
 from translations import get_translation, get_all_translations
@@ -142,6 +144,8 @@ def handle_file_too_large(e):
 
 # Execute Celery tasks synchronously when no worker is running
 app.config['CELERY_TASK_ALWAYS_EAGER'] = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'False').lower() == 'true'
+app.config['DFM_SYNC_FALLBACK'] = os.getenv('DFM_SYNC_FALLBACK', 'False').lower() == 'true'
+app.config['DFM_SYNC_TIMEOUT'] = int(os.getenv('DFM_SYNC_TIMEOUT', '30'))
 
 # Database configuration
 database_url = os.environ.get("DATABASE_URL")
@@ -1370,7 +1374,7 @@ def dfm_axes_suggest():
 
 @app.route('/api/dfm/start', methods=['POST'])
 def dfm_start():
-    """Start asynchronous DFM analysis."""
+    """Start DFM analysis with Celery if available, fallback otherwise."""
     try:
         data = request.get_json(silent=True) or {}
         file_id = data.get('fileId')
@@ -1382,9 +1386,66 @@ def dfm_start():
             return jsonify({'error': 'missing_materialProfile'}), 400
         if not demould_axis:
             return jsonify({'error': 'missing_demouldAxis'}), 400
-        task = dfm_analysis.delay(file_id, material_profile, demould_axis)
-        logger.info("DFM job queued", extra={"file_id": file_id, "job_id": task.id})
-        return jsonify({'jobId': task.id})
+
+        if current_app.config.get("CELERY_ENABLED") and is_celery_ready():
+            for attempt in range(2):
+                try:
+                    task = dfm_analysis.apply_async((file_id, material_profile, demould_axis))
+                    logger.info(
+                        "DFM job queued",
+                        extra={"file_id": file_id, "job_id": task.id},
+                    )
+                    return jsonify({'jobId': task.id, 'status': 'queued'})
+                except (
+                    RedisConnectionError,
+                    KombuOperationalError,
+                    ConnectionError,
+                ) as exc:
+                    logger.warning(
+                        "Celery queue unreachable (attempt %s)",
+                        attempt + 1,
+                        exc_info=exc,
+                    )
+                    if attempt == 0:
+                        time.sleep(0.3)
+
+        if current_app.config.get("DFM_SYNC_FALLBACK"):
+            timeout = current_app.config.get("DFM_SYNC_TIMEOUT", 30)
+
+            def run_task():
+                async_result = dfm_analysis.apply(args=(file_id, material_profile, demould_axis))
+                async_result.get()
+                return async_result.id
+
+            try:
+                with ThreadPoolExecutor(max_workers=1) as executor:
+                    job_id = executor.submit(run_task).result(timeout=timeout)
+                reports_dir = current_app.config.get("REPORTS_FOLDER", "reports")
+                json_path = os.path.join(reports_dir, f"dfm_result_{job_id}.json")
+                result = {}
+                try:
+                    with open(json_path) as fh:
+                        result = json.load(fh)
+                except FileNotFoundError:
+                    logger.warning("DFM result file missing", extra={"job_id": job_id})
+                return jsonify({'jobId': job_id, 'status': 'completed', 'result': result})
+            except TimeoutError:
+                logger.exception("DFM sync fallback timeout")
+                return jsonify({'error': 'dfm_timeout', 'message': 'Analyse trop longue'}), 504
+            except Exception as e:
+                logger.exception("DFM sync fallback failed")
+                return jsonify({'error': 'dfm_failed', 'message': str(e)}), 500
+
+        retry_after = current_app.config.get("DFM_RETRY_AFTER", 30)
+        payload = {
+            'error': 'dfm_unavailable',
+            'message': "Le service d'analyse est temporairement indisponible. Réessayez dans quelques instants.",
+            'retryAfter': retry_after,
+        }
+        response = jsonify(payload)
+        response.status_code = 503
+        response.headers['Retry-After'] = str(retry_after)
+        return response
     except Exception as e:
         logger.exception("dfm_start failed")
         return jsonify({'error': 'dfm_start_failed', 'message': str(e)}), 500
@@ -1485,6 +1546,19 @@ def health_check():
         'upload_folder': os.path.exists(UPLOAD_FOLDER),
         'converted_folder': os.path.exists(CONVERTED_FOLDER)
     })
+
+
+@app.route('/health/celery')
+def health_celery():
+    ready = is_celery_ready()
+    payload = {
+        'celery_enabled': current_app.config.get('CELERY_ENABLED', False),
+        'broker': current_app.config.get('CELERY_BROKER_URL'),
+        'backend': current_app.config.get('CELERY_RESULT_BACKEND'),
+        'ready': ready,
+    }
+    status = 200 if payload['celery_enabled'] and ready else 503
+    return jsonify(payload), status
 
 @app.route('/admin')
 def admin():


### PR DESCRIPTION
## Summary
- expose Celery broker/backend readiness via `/health/celery`
- log readiness transitions and export `celery_ready` Prometheus gauge
- retry Celery enqueue with short delay and return 503 on connection errors
- enforce short socket timeouts for Celery broker/backend
- document required Celery env vars and worker launch command
- return structured 503 with retry hint when DFM service is unavailable

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_68b6a384c5e88333825b01fbcd43d5f0