### PR TITLE
Fix Bootstrap inclusion and payload compatibility

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -190,13 +190,14 @@ class DFMOrchestrator {
     UI.setLoading(true);
 
     const payload = {
-  // double-clé pour compat avec les deux conventions
-  fileId,                  // camelCase – beaucoup de backends le lisent
-  file_id: fileId,         // snake_case – si ton backend regarde ça, il l’a aussi
-  material_profile: materialProfile,
-  demould_axis: demouldAxis
-};
-console.debug("[DFM] start payload", payload);
+      fileId,
+      file_id: fileId,
+      materialProfile,
+      material_profile: materialProfile,
+      demouldAxis,
+      demould_axis: demouldAxis
+    };
+    console.debug("[DFM] start payload", payload);
 
 
     try {
@@ -482,62 +483,59 @@ export function collectMaterialForm(){
 }
 
 // ---------------------- Wiring des boutons ----------------------
-document.addEventListener("DOMContentLoaded", ()=>{
+document.addEventListener("DOMContentLoaded", () => {
+  // Récupération des éléments
   const modalEl = document.getElementById("materialQuestionnaireModal");
-  let modal = null;
+  const btn = document.getElementById("submitQuestionnaire");
+  const analyzeBtn = document.getElementById("dfmAnalyzeBtn");
 
+  // Sécurité : si le bouton n'existe pas, on sort proprement
+  if (!btn) {
+    console.warn("[DFM] #submitQuestionnaire introuvable");
+    return;
+  }
+
+  // Modal Bootstrap si dispo, sinon fallback maison
+  let modal = null;
   if (modalEl) {
     if (window.bootstrap?.Modal) {
       modal = new bootstrap.Modal(modalEl);
     } else {
-      // Fallback ultra simple si Bootstrap n'est pas dispo
       modal = {
-        show(){ modalEl.classList.add("show"); modalEl.style.display = "block"; modalEl.removeAttribute("aria-hidden"); },
-        hide(){ modalEl.classList.remove("show"); modalEl.style.display = "none"; modalEl.setAttribute("aria-hidden","true"); }
+        show(){ modalEl.classList.add("show"); modalEl.style.display="block"; modalEl.removeAttribute("aria-hidden"); },
+        hide(){ modalEl.classList.remove("show"); modalEl.style.display="none"; modalEl.setAttribute("aria-hidden","true"); }
       };
     }
   }
 
-  const btn = document.getElementById("submitQuestionnaire");
-  if (!btn) return;
+  // Ouvre le questionnaire matière quand on clique "Analyser"
+  analyzeBtn?.addEventListener("click", () => {
+    if (!dfmOrchestrator.setFileIdFromPage()){
+      UI.info("Aucun fichier à analyser. Merci d’importer une pièce.");
+      return;
+    }
+    modal?.show?.();
+  });
 
-  // ... (le reste de ton listener 'click' inchangé)
-});
-
+  // Normalise un profil matière minimal
+  const arr = v => Array.isArray(v) ? v : (v ? [v] : []);
   function normalizeProfile(raw){
-    const arr = v => Array.isArray(v) ? v : (v ? [v] : []);
-    const prof = raw && typeof raw === "object" ? raw : {};
+    const p = raw && typeof raw === "object" ? raw : {};
     return {
-      mechanical: arr(prof.mechanical),
-      aesthetic:  arr(prof.aesthetic),
-      regulatory: arr(prof.regulatory),
-      resin:      prof.resin || null,
-      notes:      prof.notes || ""
+      mechanical: arr(p.mechanical),
+      aesthetic:  arr(p.aesthetic),
+      regulatory: arr(p.regulatory),
+      resin:      p.resin || "generic",
+      notes:      p.notes || ""
     };
   }
-  function isProfileEmpty(p){
-    return (!p) ||
-           ((!p.resin || p.resin === "") &&
-            (!p.notes || p.notes === "") &&
-            (!Array.isArray(p.mechanical) || p.mechanical.length===0) &&
-            (!Array.isArray(p.aesthetic)  || p.aesthetic.length===0) &&
-            (!Array.isArray(p.regulatory) || p.regulatory.length===0));
-  }
 
-  btn.addEventListener("click", ()=>{
+  btn.addEventListener("click", () => {
     UI.setLoading(true);
-    try{
-      // 1) collecte
-      let result = collectMaterialForm?.();
-      let profile = normalizeProfile(result?.data);
+    try {
+      const result  = typeof collectMaterialForm === "function" ? collectMaterialForm() : { data: {} };
+      const profile = normalizeProfile(result?.data);
 
-      // 2) si vide, on met un profil minimal (au moins un champ présent)
-      if (isProfileEmpty(profile)) {
-        profile = { mechanical: [], aesthetic: [], regulatory: [], resin: "generic", notes: "" };
-        console.warn("[DFM] materialProfile vide -> usage d’un profil minimal:", profile);
-      }
-
-      // 3) mémorise + logs
       dfmOrchestrator.setMaterialProfile(profile);
       dfmOrchestrator.setFileIdFromPage();
       console.debug("[DFM] materialProfile:", profile, "fileId:", dfmOrchestrator.fileId);
@@ -547,14 +545,14 @@ document.addEventListener("DOMContentLoaded", ()=>{
         return;
       }
 
-      // 4) ferme le modal et passe à l’axe
-      modal?.hide();
+      modal?.hide?.();
       dfmOrchestrator.setState(DFM_STATES.MATERIAL_CONFIRMED);
       dfmOrchestrator.setState(DFM_STATES.AXIS_PICK);
-    } catch (e){
+    } catch (e) {
       console.error(e);
       UI.err(e?.message || "Formulaire invalide");
     } finally {
       UI.setLoading(false);
     }
+  });
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CADlytitcs - {% if current_language == 'en' %}DFM Analysis Application{% else %}Application d'analyse DFM{% endif %}</title>
     
-<!-- Bootstrap CSS 5.3.3 (une seule fois) -->
+<!-- Bootstrap CSS 5.3.3 -->
 <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
       integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
@@ -756,20 +756,17 @@
               });
             </script>
 
-<!-- Bootstrap JS 5.3.3 (une seule fois, avant DFMOrchestrator) -->
+<!-- Bootstrap JS 5.3.3 — placer AVANT DFMOrchestrator -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmCs59fDVLZesaAA55DNz0xhy9GkcIdsl1keM7N6jIeHz"
+        integrity="sha384-YvpcrYf0tY3lHB60NNkmCs59fDVLZesaAA55DNz0xhy9GkcIdsl1keM7N6jIehZ"
         crossorigin="anonymous"></script>
 
-<!-- Orchestrateur (une seule inclusion) -->
 <script type="module" src="{{ url_for('static', filename='js/DFMOrchestrator.js') }}"></script>
 
-<!-- Tooltips (protégé si Bootstrap absent) -->
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    if (window.bootstrap && bootstrap.Tooltip) {
-      const els = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-      els.forEach(el => new bootstrap.Tooltip(el));
+    if (window.bootstrap?.Tooltip) {
+      document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
     }
   });
 </script>

--- a/web.py
+++ b/web.py
@@ -1369,15 +1369,15 @@ def dfm_start():
     """Start asynchronous DFM analysis."""
     try:
         data = request.get_json(silent=True) or {}
-        file_id = data.get('fileId')
-        material_profile = data.get('materialProfile')
-        demould_axis = data.get('demouldAxis')
+        file_id = data.get("file_id") or data.get("fileId")
+        material_profile = data.get("material_profile") or data.get("materialProfile")
+        demould_axis = data.get("demould_axis") or data.get("demouldAxis")
         if not file_id:
-            return jsonify({'error': 'missing_fileId'}), 400
+            return jsonify({"error": "missing_fileId"}), 400
         if not material_profile:
-            return jsonify({'error': 'missing_materialProfile'}), 400
+            return jsonify({"error": "missing_materialProfile"}), 400
         if not demould_axis:
-            return jsonify({'error': 'missing_demouldAxis'}), 400
+            return jsonify({"error": "missing_demouldAxis"}), 400
         task = dfm_analysis.delay(file_id, material_profile, demould_axis)
         logger.info("DFM job queued", extra={"file_id": file_id, "job_id": task.id})
         return jsonify({'jobId': task.id})


### PR DESCRIPTION
## Summary
- align Bootstrap 5.3.3 includes and initialize tooltips
- fallback modal if Bootstrap is missing
- send camelCase and snake_case keys in analysis payload
- accept camelCase or snake_case in server DFM start handler

## Testing
- `pytest` *(fails: ModuleNotFoundError: requests, cadquery, flask)*

------
https://chatgpt.com/codex/tasks/task_e_68b83aee46888333999217171694aa31