### PR TITLE
Add init_celery helper to Celery app

### DIFF
--- a/celery_app.py
+++ b/celery_app.py
@@ -1,24 +1,42 @@
 import os
 from celery import Celery
 
+
 def make_celery():
     broker = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
     backend = os.getenv("CELERY_RESULT_BACKEND", broker)
 
     app = Celery(__name__, broker=broker, backend=backend)
-
-    # Queue par défaut
     app.conf.task_default_queue = os.getenv("CELERY_DEFAULT_QUEUE", "dfm")
+    app.conf.broker_connection_retry_on_startup = True
 
-    # Redis Cloud => TLS (rediss://). Active SSL côté Celery si nécessaire.
+    # Redis Cloud via TLS (rediss://) → activer SSL côté Celery si nécessaire
     if broker.startswith("rediss://"):
         app.conf.broker_use_ssl = {"ssl_cert_reqs": "none"}
     if backend.startswith("rediss://"):
         app.conf.redis_backend_use_ssl = {"ssl_cert_reqs": "none"}
 
-    # Optionnel mais utile en prod
-    app.conf.broker_connection_retry_on_startup = True
-
     return app
 
+
 celery = make_celery()
+
+
+def init_celery(flask_app):
+    """
+    Optionnel : lie Celery au contexte Flask pour que les tasks aient app_context.
+    Laisse intact 'celery' pour compat avec l'ancien import 'from celery_app import celery, init_celery'.
+    """
+    celery.conf.update(flask_app.config)
+
+    TaskBase = celery.Task
+
+    class ContextTask(TaskBase):
+        abstract = True
+
+        def __call__(self, *args, **kwargs):
+            with flask_app.app_context():
+                return TaskBase.__call__(self, *args, **kwargs)
+
+    celery.Task = ContextTask
+    return celery

--- a/web.py
+++ b/web.py
@@ -157,8 +157,9 @@ app.config["SQLALCHEMY_ENGINE_OPTIONS"] = {
 # Initialize database
 db.init_app(app)
 migrate = Migrate(app, db)
-
-init_celery(app)
+if not app.config['CELERY_TASK_ALWAYS_EAGER']:
+    # Optionnel : attache le contexte Flask aux tâches Celery
+    init_celery(app)
 from celery.schedules import crontab
 
 celery.conf.beat_schedule = {


### PR DESCRIPTION
## Summary
- add make_celery wrapper with broker TLS handling and default queue
- add init_celery to bind Celery tasks to Flask application context
- call init_celery in web app only when tasks run asynchronously

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'flask')

------
https://chatgpt.com/codex/tasks/task_e_68b94f4b89a08333a8ab7020e45bceb6