### PR TITLE
Dézoom auto et fond gris sur le viewer

### DIFF
--- a/static/js/init_xeokit.js
+++ b/static/js/init_xeokit.js
@@ -5,8 +5,11 @@ function initXeokit(stlUrl) {
     }
 
     const viewer = new Viewer({
-        canvasId: 'myCanvas'
+        canvasId: 'myCanvas',
+        transparent: false,
+        backgroundColor: [0.9, 0.9, 0.9]
     });
+    viewer.cameraFlight.fitFOV = 20;
 
     const loader = new STLLoaderPlugin(viewer);
 

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -11,7 +11,12 @@ import {
 export class XeokitModelViewer extends EventTarget {
   constructor(canvasId) {
     super();
-    this.viewer = new Viewer({ canvasId });
+    this.viewer = new Viewer({
+      canvasId,
+      transparent: false,
+      backgroundColor: [0.9, 0.9, 0.9],
+    });
+    this.viewer.cameraFlight.fitFOV = 20;
     this.loader = new XKTLoaderPlugin(this.viewer);
     this.edges = new EdgesPlugin(this.viewer);
     this.sections = new SectionPlanesPlugin(this.viewer);
@@ -49,8 +54,9 @@ export class XeokitModelViewer extends EventTarget {
     }
     this.model = await this.loader.load({ id: this.modelId, src: url });
     if (this.currentQuality === null) {
-      // première fois -> cadrage automatique
-      this.viewer.cameraFlight.flyTo(this.model);
+      // première fois -> cadrage automatique et dézoom
+      const aabb = this.viewer.scene.getAABB();
+      this.viewer.cameraFlight.flyTo({ aabb, fitFOV: 20 });
       this.dispatchEvent(new CustomEvent("onAssetLoaded", { detail: { url } }));
     } else {
       // upgrade/downgrade -> restituer caméra


### PR DESCRIPTION
## Summary
- centrage automatique et léger dézoom lors du chargement du modèle
- fond gris appliqué au canvas pour mieux distinguer les pièces blanches

## Testing
- `pytest` *(échoué : ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68bbe61cc75c8333b39cacb6f28ee443