### PR TITLE
feat(viewer): improve camera centering and dark background

### DIFF
--- a/static/css/viewer.css
+++ b/static/css/viewer.css
@@ -12,6 +12,7 @@
   width: 100%;
   height: 100%;
   display: block;
+  background-color: #101218;
 }
 
 /* NEW: barre d’outils */

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -7,6 +7,31 @@ import {
   AnnotationsPlugin
 } from "@xeokit/xeokit-sdk";
 
+export function flyToAABB(viewer, aabb, duration = 0.8, padding = 1.15) {
+  if (!viewer || !aabb) return;
+  const [minX, minY, minZ, maxX, maxY, maxZ] = aabb;
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const cz = (minZ + maxZ) / 2;
+  const dx = ((maxX - minX) * padding) / 2;
+  const dy = ((maxY - minY) * padding) / 2;
+  const dz = ((maxZ - minZ) * padding) / 2;
+  viewer.cameraFlight.flyTo({
+    aabb: [cx - dx, cy - dy, cz - dz, cx + dx, cy + dy, cz + dz],
+    duration,
+  });
+}
+
+export function centerPivotOnAABB(viewer, aabb) {
+  if (!viewer || !aabb) return;
+  const [minX, minY, minZ, maxX, maxY, maxZ] = aabb;
+  const cx = (minX + maxX) / 2;
+  const cy = (minY + maxY) / 2;
+  const cz = (minZ + maxZ) / 2;
+  viewer.cameraControl.pivotPoint = [cx, cy, cz];
+  viewer.cameraControl.followPointer = true;
+}
+
 // Gestionnaire de visualisation avec swap preview/final + overlay DFM
 export class XeokitModelViewer extends EventTarget {
   constructor(canvasId) {
@@ -14,8 +39,8 @@ export class XeokitModelViewer extends EventTarget {
     this.viewer = new Viewer({
       canvasId,
       transparent: false,
-      backgroundColor: [0.9, 0.9, 0.9],
     });
+    this.viewer.scene.clearColor = [0.06, 0.07, 0.09];
     this.viewer.cameraFlight.fitFOV = 20;
     this.loader = new XKTLoaderPlugin(this.viewer);
     this.edges = new EdgesPlugin(this.viewer);
@@ -28,6 +53,12 @@ export class XeokitModelViewer extends EventTarget {
     this.currentQuality = null; // 'preview' | 'final'
     this.heatmapActive = false;
     this.colorBuffer = null; // stocke vertex/face colors
+    this.lastAABB = null;
+    window.addEventListener("resize", () => {
+      if (this.lastAABB) {
+        flyToAABB(this.viewer, this.lastAABB);
+      }
+    });
   }
 
   // === Mini-patch : expose l’ID côté front (DOM + global + event)
@@ -53,10 +84,19 @@ export class XeokitModelViewer extends EventTarget {
       this.model.destroy();
     }
     this.model = await this.loader.load({ id: this.modelId, src: url });
+    this.lastAABB = [...this.model.aabb];
     if (this.currentQuality === null) {
-      // première fois -> cadrage automatique et dézoom
-      const aabb = this.viewer.scene.getAABB();
-      this.viewer.cameraFlight.flyTo({ aabb, fitFOV: 20 });
+      const fit = () => {
+        const aabb = this.model.aabb;
+        this.lastAABB = [...aabb];
+        flyToAABB(this.viewer, aabb);
+        centerPivotOnAABB(this.viewer, aabb);
+      };
+      if (this.model.built) {
+        fit();
+      } else {
+        this.model.on("built", fit);
+      }
       this.dispatchEvent(new CustomEvent("onAssetLoaded", { detail: { url } }));
     } else {
       // upgrade/downgrade -> restituer caméra

--- a/templates/viewer_example.html
+++ b/templates/viewer_example.html
@@ -8,7 +8,7 @@
         #toolbar { display:flex; gap:8px; padding:4px; background:#eee; align-items:center; }
         #progressContainer { flex:1; height:6px; background:#ccc; margin-right:8px; }
         #progressBar { height:100%; width:0; background:#4caf50; }
-        #viewerCanvas { width:100%; height:calc(100% - 40px); display:block; }
+        #viewerCanvas { width:100%; height:calc(100% - 40px); display:block; background-color:#101218; }
         #dfmPanel { position:absolute; top:40px; right:0; width:200px; background:rgba(255,255,255,0.9); max-height:50%; overflow:auto; }
         #dfmPanel ul { list-style:none; padding:0; margin:0; }
         #dfmPanel li { padding:4px; cursor:pointer; }


### PR DESCRIPTION
## Summary
- set dark WebGL clear color for 3D viewer
- ensure viewer canvas uses dark CSS background
- add flyToAABB helper for camera recentering
- auto-fit camera to model AABB after load
- center camera pivot on model for intuitive rotation
- refit camera on window resize using stored AABB

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cadquery'; ImportError: cannot import name 'db' from 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68bbf35c58188333818c4471bb034c76