### PR TITLE
Lance l'analyse après validation de l'axe

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -185,6 +185,10 @@ class DFMOrchestrator {
     const chosen = sel.axis === "AUTO" && this._autoSuggestion ? this._autoSuggestion : sel;
     this.setDemouldAxis(chosen);
     dbg("confirmAxis", chosen);
+    if (!this.fileId) this.setFileIdFromPage();
+    if (!this.fileId){ UI.err("Aucun fichier à analyser"); return; }
+    if (!this.materialProfile){ UI.err("Profil matière manquant"); return; }
+    this.startAnalysis();
   }
 
   // ---------------------- Analyse ----------------------


### PR DESCRIPTION
## Résumé
- déclenche automatiquement l'analyse DFM dès la validation de l'axe de démoulage
- vérifie la présence de `fileId` et `materialProfile` avant de démarrer l'analyse

## Tests
- `npm test` (échoue : "no test specified")
- `pytest -q` (échoue : ImportError 'db' dans app)


------
https://chatgpt.com/codex/tasks/task_e_68beaf879b2083338775c9dbcea793ca