### PR TITLE
feat: centralize data directory configuration

### DIFF
--- a/app/dfm/services.py
+++ b/app/dfm/services.py
@@ -12,10 +12,11 @@ from typing import Any, Dict
 import numpy as np
 
 from app.storage import files
+from app.storage.files import DATA_DIR
 from .dfm_analyzer import analyze_dfm
 from .interfaces import Axis, DFMResult, Heatmap, HeatmapEntry, MaterialProfile, Summary
 
-RESULTS_DIR = Path(os.getenv("RESULTS_DIR", "/data/results"))
+RESULTS_DIR = Path(os.getenv("RESULTS_DIR", DATA_DIR / "results"))
 RESULTS_DIR.mkdir(parents=True, exist_ok=True)
 
 LOG_PATH = Path(os.getenv("DFM_LOG", "logs/dfm.log"))

--- a/app/storage/__init__.py
+++ b/app/storage/__init__.py
@@ -3,12 +3,16 @@
 DFM lit STEP, viewer lit XKT.
 """
 import os
+from pathlib import Path
+
+# Répertoire racine configurable
+DATA_DIR = Path(os.getenv("DATA_DIR", "data")).resolve()
 
 
 class Storage:
     """Centralise l'accès aux fichiers locaux."""
 
-    UPLOADS_DIR = os.path.join("/data", "uploads")
+    UPLOADS_DIR = str(Path(os.getenv("UPLOAD_FOLDER", DATA_DIR / "uploads")))
     CONVERTED_DIR = "converted"
     DFM_ROOT = os.path.join("static", "dfm")
 
@@ -44,3 +48,6 @@ class Storage:
 
 
 __all__ = ["Storage"]
+
+# Création du dossier d'uploads au chargement du module
+Path(Storage.UPLOADS_DIR).mkdir(parents=True, exist_ok=True)

--- a/app/storage/files.py
+++ b/app/storage/files.py
@@ -6,12 +6,15 @@ from pathlib import Path
 from typing import Optional
 from werkzeug.utils import secure_filename
 
+# Répertoire racine configurable
+DATA_DIR = Path(os.getenv("DATA_DIR", "data")).resolve()
+
 # Répertoire par défaut pour les STEP
-UPLOAD_DIR = Path(os.getenv("UPLOAD_FOLDER", "/data/uploads"))
+UPLOAD_DIR = Path(os.getenv("UPLOAD_FOLDER", DATA_DIR / "uploads"))
 UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
 
 # Base de données pour persister les métadonnées
-DB_PATH = Path(os.getenv("FILES_DB", "/data/files.sqlite"))
+DB_PATH = Path(os.getenv("FILES_DB", DATA_DIR / "files.sqlite"))
 
 
 def _init_db() -> None:

--- a/render.yaml
+++ b/render.yaml
@@ -23,6 +23,8 @@ services:
         value: "300"
       - key: OMP_NUM_THREADS
         value: "1"
+      - key: DATA_DIR
+        value: ./data # personnaliser si un volume persistant est monté
     plan: starter
 
   - type: worker
@@ -46,6 +48,8 @@ services:
         value: /tmp/converted
       - key: OMP_NUM_THREADS
         value: "1"
+      - key: DATA_DIR
+        value: ./data # personnaliser si un volume persistant est monté
 
 databases:
   - name: cadlytics-redis


### PR DESCRIPTION
## Summary
- make storage paths relative to configurable DATA_DIR
- ensure uploads, DB and results folders exist
- document DATA_DIR env var for render deployments

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: InvalidVersion: 'x86_64')*

------
https://chatgpt.com/codex/tasks/task_e_68beb346fcc8833388947df29f8b603e