### PR TITLE
Affiche le questionnaire matière avant l'analyse

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -524,13 +524,25 @@ document.addEventListener("DOMContentLoaded", () => {
   document.addEventListener('material:confirmed', e => {
     window.CAD.materialProfile = e.detail;
     dfmOrchestrator.setMaterialProfile(e.detail);
+    if (!dfmOrchestrator.demouldAxis) {
+      dfmOrchestrator.renderAxisPanel();
+    } else {
+      dfmOrchestrator.startAnalysis();
+    }
   });
 
   const analyzeBtn = document.getElementById("dfmAnalyzeBtn");
   analyzeBtn?.addEventListener("click", () => {
     const { fileIdStep, materialProfile } = window.CAD;
     if (!fileIdStep){ UI.info("Importe d'abord un STEP"); return; }
-    if (!materialProfile){ UI.info("Sélectionne un matériau"); return; }
+    if (!materialProfile){
+      const modalEl = document.getElementById('materialQuestionnaireModal');
+      if (modalEl) {
+        const instance = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+        instance.show();
+      }
+      return;
+    }
     if (!dfmOrchestrator.demouldAxis){ dfmOrchestrator.renderAxisPanel(); return; }
     dfmOrchestrator.setFileId(fileIdStep);
     dfmOrchestrator.setMaterialProfile(materialProfile);

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -128,7 +128,7 @@ function updateSummary() {
   if (summary) {
     summary.textContent = `✅ Valides: ${valids.length} | ⚠️ Avertissements: ${state.warnings.size} | ⛔ Blocants: ${state.blockers.size}`;
   }
-  const btn = document.getElementById("analyserBtn");
+  const btn = document.getElementById("submitQuestionnaire");
   if (btn) btn.disabled = state.blockers.size > 0;
 }
 
@@ -245,12 +245,13 @@ function onAnalyseClick(e) {
     first?.focus();
     return;
   }
-  if (typeof startDFM === "function") {
-    startDFM(res.payload);
-  } else {
-    document.dispatchEvent(
-      new CustomEvent("start-dfm", { detail: res.payload })
-    );
+  document.dispatchEvent(
+    new CustomEvent("material:confirmed", { detail: res.payload })
+  );
+  const modalEl = document.getElementById("materialQuestionnaireModal");
+  if (modalEl) {
+    const instance = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
+    instance.hide();
   }
 }
 
@@ -271,7 +272,7 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document
-    .getElementById("analyserBtn")
+    .getElementById("submitQuestionnaire")
     ?.addEventListener("click", onAnalyseClick);
 
   evaluate();


### PR DESCRIPTION
## Summary
- Affiche le questionnaire matière lorsqu'on lance l'analyse sans matériau sélectionné
- Envoie l'événement `material:confirmed` depuis le formulaire et ferme la modal

## Testing
- `pytest` (errors: ImportError: cannot import name 'db' from 'app')

------
https://chatgpt.com/codex/tasks/task_e_68bec3a1faac8333b5da1bd18ec40091