### PR TITLE
feat: charge bootstrap via cdn et ajoute modale matière

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -23,7 +23,7 @@ const UI = {
   warn(m){ if (window.showToast) showToast(m,{type:"warn"}); },
   err(m){  if (window.showToast) showToast(m,{type:"error"}); },
   setLoading(on){
-    const b = document.getElementById("dfmAnalyzeBtn");
+    const b = document.getElementById("analyzeBtn");
     if (b) b.disabled = !!on;
   },
   progress(pct){
@@ -79,6 +79,22 @@ async function pollJobStatus(jobId, onUpdate, onDone, onError) {
   }
   step();
 }
+
+export function showMaterialModal() {
+  if (!window.bootstrap) {
+    console.error("Bootstrap non chargé : modale impossible.");
+    alert("Erreur UI : recharge la page.");
+    return;
+  }
+  const el = document.getElementById('materialModal');
+  if (!el) {
+    console.error("#materialModal introuvable");
+    return;
+  }
+  const modal = new bootstrap.Modal(el, { backdrop: 'static' });
+  modal.show();
+}
+window.showMaterialModal = showMaterialModal;
 
 // ---------------------- États ----------------------
 export const DFM_STATES = {
@@ -197,6 +213,11 @@ class DFMOrchestrator {
     materialProfile = this.materialProfile,
     demouldAxis = this.demouldAxis
   } = {}) {
+    if (!this.materialProfile) {
+      console.warn("Aucun profil matière sélectionné, ouverture de la modale.");
+      showMaterialModal();
+      return;
+    }
     // ➊ Résolution robuste du fileId au tout début
     if (!fileId) {
       // a) champ caché
@@ -433,6 +454,7 @@ class DFMOrchestrator {
 }
 
 export const dfmOrchestrator = new DFMOrchestrator();
+window.DFMOrchestrator = dfmOrchestrator;
 
 // ---------------------- Formulaire matière ----------------------
 const EXCLUSIVE_GROUPS = [
@@ -530,22 +552,42 @@ document.addEventListener("DOMContentLoaded", () => {
       dfmOrchestrator.startAnalysis();
     }
   });
+});
 
-  const analyzeBtn = document.getElementById("dfmAnalyzeBtn");
-  analyzeBtn?.addEventListener("click", () => {
-    const { fileIdStep, materialProfile } = window.CAD;
-    if (!fileIdStep){ UI.info("Importe d'abord un STEP"); return; }
-    if (!materialProfile){
-      const modalEl = document.getElementById('materialQuestionnaireModal');
-      if (modalEl) {
-        const instance = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
-        instance.show();
+document.addEventListener('DOMContentLoaded', () => {
+  const analyzeBtn = document.getElementById('analyzeBtn');
+  if (!analyzeBtn) {
+    console.warn("#analyzeBtn introuvable");
+    return;
+  }
+  if (!analyzeBtn.dataset.bound) {
+    analyzeBtn.dataset.bound = "1";
+    analyzeBtn.addEventListener('click', (e) => {
+      e.preventDefault();
+      try {
+        if (typeof DFMOrchestrator?.startAnalysis === 'function') {
+          DFMOrchestrator.startAnalysis();
+        } else if (typeof startAnalysis === 'function') {
+          startAnalysis();
+        } else {
+          console.error("startAnalysis introuvable");
+          if (window.showMaterialModal) showMaterialModal();
+        }
+      } catch (err) {
+        console.error("Erreur au clic Analyser:", err);
       }
-      return;
-    }
-    if (!dfmOrchestrator.demouldAxis){ dfmOrchestrator.renderAxisPanel(); return; }
-    dfmOrchestrator.setFileId(fileIdStep);
-    dfmOrchestrator.setMaterialProfile(materialProfile);
-    dfmOrchestrator.startAnalysis();
-  });
+    });
+  }
+});
+
+document.getElementById('materialConfirmBtn')?.addEventListener('click', () => {
+  console.debug("[DFM] Matière confirmée");
+  const el = document.getElementById('materialModal');
+  if (el && window.bootstrap) {
+    const modal = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
+    modal.hide();
+  }
+  if (typeof DFMOrchestrator?.launchAxisPicking === 'function') {
+    DFMOrchestrator.launchAxisPicking();
+  }
 });

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -250,8 +250,7 @@ function onAnalyseClick(e) {
   );
   const modalEl = document.getElementById("materialQuestionnaireModal");
   if (modalEl) {
-    const instance = bootstrap.Modal.getInstance(modalEl) || new bootstrap.Modal(modalEl);
-    instance.hide();
+    bootstrap.Modal.getInstance(modalEl)?.hide();
   }
 }
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,10 +7,19 @@
     <title>CADlytitcs - {% if current_language == 'en' %}DFM Analysis Application{% else %}Application d'analyse DFM{% endif %}</title>
     
 <!-- Bootstrap CSS 5.3.3 -->
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
-      crossorigin="anonymous">
+<link
+  href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+  rel="stylesheet"
+  integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH"
+  crossorigin="anonymous"
+/> 
+
+<script
+  src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
+  integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz"
+  crossorigin="anonymous"
+  defer
+></script>
     
     <!-- Custom CSS -->
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
@@ -23,7 +32,7 @@
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css">
 
     <script>window.CAD={fileIdStep:null,materialProfile:null,axis:{x:0,y:0,z:1},currentJobId:null};</script>
-    <script type="module" src="/static/dist/main.js"></script>
+    <script type="module" src="/static/dist/main.js" defer></script>
 
     <!-- Plausible Analytics -->
     <script async defer data-domain="cadlytics.replit.app" src="https://plausible.io/js/script.js"></script>
@@ -242,7 +251,7 @@
 
     <!-- ✅ Outils DFM existants (inchangés) -->
     <div id="dfmControls" data-viewer-required class="d-flex flex-wrap align-items-start gap-3 mt-4">
-      <button type="button" class="btn btn-primary" id="dfmAnalyzeBtn">
+      <button type="button" class="btn btn-primary" id="analyzeBtn">
         <i class="bi bi-search me-2"></i>Analyser
         <input type="hidden" id="fileId" value="">
       </button>
@@ -712,7 +721,22 @@
             </div>
         </div>
     </footer>
-
+    <div class="modal fade" id="materialModal" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Choix matière</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Fermer"></button>
+          </div>
+          <div class="modal-body">
+            <div id="materialSelector"></div>
+          </div>
+          <div class="modal-footer">
+            <button id="materialConfirmBtn" type="button" class="btn btn-primary" data-action="material-confirm">Valider</button>
+          </div>
+        </div>
+      </div>
+    </div>
 
             <script>
               document.addEventListener('DOMContentLoaded', () => {
@@ -750,12 +774,7 @@
               });
             </script>
 
-<!-- Bootstrap JS 5.3.3 — placer AVANT DFMOrchestrator -->
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-YvpcrYf0tY3lHB60NNkmCs59fDVLZesaAA55DNz0xhy9GkcIdsl1keM7N6jIehZ"
-        crossorigin="anonymous"></script>
-
-<script type="module" src="{{ url_for('static', filename='js/DFMOrchestrator.js') }}"></script>
+<script type="module" src="{{ url_for('static', filename='js/DFMOrchestrator.js') }}" defer></script>
 
 <script>
   document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
## Summary
- load Bootstrap 5.3.3 CSS and bundle JS from CDN in main layout
- defer app scripts and avoid duplicate Bootstrap includes
- add `materialModal` with confirmation button before `</body>`
- secure material modal opening by checking Bootstrap and element presence
- show material modal if no material profile is set before analysis
- bind `#analyzeBtn` click to run `startAnalysis` safely
- hide material modal on confirmation and trigger axis picking

## Testing
- `pytest` *(fails: ImportError: cannot import name 'db' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68bed18276848333890a844016f1e989