### PR TITLE
Utilisation du bon modal matière

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -82,18 +82,10 @@ async function pollJobStatus(jobId, onUpdate, onDone, onError) {
   step();
 }
 
-export function showMaterialModal(prefill) {
+export function showMaterialModal() {
   if (!window.bootstrap) { console.error("Bootstrap non chargé"); return; }
-  const el = document.getElementById('materialModal');
-  if (!el) { console.error("#materialModal introuvable"); return; }
-
-  const profile = prefill || this?.materialProfile || null;
-  // Injection / pré-remplissage
-  try {
-    // renderMaterialSelector('#materialSelector', profile);
-    // renderFinishSelector('#materialFinish', profile);
-  } catch (e) { console.warn("Material selector injection skipped:", e); }
-
+  const el = document.getElementById('materialQuestionnaireModal');
+  if (!el) { console.error("#materialQuestionnaireModal introuvable"); return; }
   const modal = new bootstrap.Modal(el, { backdrop: 'static' });
   modal.show();
 }
@@ -551,24 +543,6 @@ export function initDFMUI() {
     window.showMaterialModal = showMaterialModal;
   }
 
-  (function bindMaterialConfirm(){
-    const btn = document.getElementById('materialConfirmBtn');
-    if (!btn || btn.dataset.bound) return;
-    btn.dataset.bound = "1";
-    btn.addEventListener('click', ()=> {
-      const el = document.getElementById('materialModal');
-      if (el && window.bootstrap) {
-        const m = bootstrap.Modal.getInstance(el) || new bootstrap.Modal(el);
-        m.hide();
-      }
-      if (typeof DFMOrchestrator?.launchAxisPicking === 'function') {
-        DFMOrchestrator.launchAxisPicking();
-      } else if (typeof launchAxisPicking === 'function') {
-        launchAxisPicking();
-      }
-    });
-  })();
-
   document.addEventListener("DOMContentLoaded", () => {
     dfmOrchestrator.setFileId(window.CAD.fileIdStep);
     dfmOrchestrator.setMaterialProfile(window.CAD.materialProfile);
@@ -621,7 +595,7 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 function dfmSelfCheck() {
   const errors = [];
   if (!window.bootstrap || !bootstrap.Modal) errors.push("bootstrap.Modal absent");
-  if (!document.getElementById('materialModal')) errors.push("#materialModal absent");
+  if (!document.getElementById('materialQuestionnaireModal')) errors.push("#materialQuestionnaireModal absent");
   if (!document.getElementById('analyzeBtn')) errors.push("#analyzeBtn absent");
 
   if (errors.length) {

--- a/templates/index.html
+++ b/templates/index.html
@@ -786,6 +786,7 @@
               });
             </script>
 
+<script type="module" src="{{ url_for('static', filename='js/criteria-modal.js') }}" defer></script>
 <script type="module" src="{{ url_for('static', filename='js/DFMOrchestrator.js') }}" defer></script>
 
 <script>

--- a/tests-e2e/modal-material.spec.ts
+++ b/tests-e2e/modal-material.spec.ts
@@ -6,15 +6,10 @@ test('Ouverture et fermeture du modal matière', async ({ page }) => {
   await expect(analyze).toBeVisible();
 
   await analyze.click();
-  const modal = page.locator('#materialModal.show, .modal.show:has(#materialModal)');
+  const modal = page.locator('#materialQuestionnaireModal.show, .modal.show:has(#materialQuestionnaireModal)');
   await expect(modal).toBeVisible();
 
-  const cancel = page.locator('#materialCancelBtn');
-  if (await cancel.isVisible()) {
-    await cancel.click();
-  } else {
-    await page.keyboard.press('Escape');
-  }
+  await modal.getByRole('button', { name: 'Annuler' }).click();
 
-  await expect(page.locator('#materialModal.show')).toHaveCount(0);
+  await expect(page.locator('#materialQuestionnaireModal.show')).toHaveCount(0);
 });


### PR DESCRIPTION
## Résumé
- branche <analyze>: ouvre désormais le questionnaire matière complet
- ajout du script `criteria-modal.js` pour la logique métier
- mise à jour du test e2e pour viser le nouveau modal

## Tests
- `pytest tests/test_dfm_analyzer_unit.py`
- `npx playwright test tests-e2e/modal-material.spec.ts` *(échoué: Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd48dd1fc8333bdd292f08ab5f808