### PR TITLE
Add frontend event bus and axis validation flow

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -10,6 +10,7 @@ from flask_compress import Compress
 from .jobs import generate_low_preview, generate_full_model
 from .queue import q, conn
 from .tasks import heavy_compute
+from server.dfm_api_blueprint_stub import dfm_bp
 
 app = Flask(__name__)
 app.config["UPLOAD_FOLDER"] = os.getenv("UPLOAD_FOLDER", "/tmp/uploads")
@@ -29,6 +30,8 @@ os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
 
 compress = Compress()
 compress.init_app(app)
+
+app.register_blueprint(dfm_bp)
 
 
 def cleanup_output_folder(max_age_hours: int = 72) -> None:
@@ -184,6 +187,17 @@ def index():
         "index.html",
         max_upload_mb=app.config["MAX_CONTENT_LENGTH"] // (1024 * 1024),
     )
+
+
+def log_routes() -> None:
+    lines = []
+    for rule in app.url_map.iter_rules():
+        methods = ",".join(sorted(rule.methods - {"HEAD", "OPTIONS"}))
+        lines.append(f"{methods} {rule.rule}")
+    logger.info("Routes:\n%s", "\n".join(sorted(lines)))
+
+
+log_routes()
 
 if __name__ == "__main__":
     app.run()

--- a/docs/DFM_EVENTS.md
+++ b/docs/DFM_EVENTS.md
@@ -1,0 +1,44 @@
+# DFM Events
+
+Ce document standardise les événements émis sur le bus d'événements pour la coordination des modules front.
+
+## `material:selected`
+
+Payload :
+
+```json
+{
+  "materialProfile": { /* objet profil matière */ }
+}
+```
+
+Émis lors de la validation de la modale matière.
+
+## `axis:validated`
+
+Payload :
+
+```json
+{
+  "axis": [x, y, z],
+  "invert": bool,
+  "ts": 1234567890
+}
+```
+
+Émis au clic sur le bouton « Valider l'axe ».
+
+## `dfm:start`
+
+Payload :
+
+```json
+{
+  "file_id": "abc123",
+  "material_profile_id": "mat42",
+  "axis": [x, y, z] | null,
+  "invert": bool
+}
+```
+
+Émis juste avant l'appel réseau d'analyse DFM.

--- a/docs/QA_CHECKS_AXIS_AND_MATERIAL.md
+++ b/docs/QA_CHECKS_AXIS_AND_MATERIAL.md
@@ -1,0 +1,16 @@
+# Vérifications QA axe & matière
+
+## Gating
+- [ ] À l'ouverture, le panneau axe est caché.
+- [ ] Après `material:selected` avec `fileId` présent, le panneau axe devient visible.
+- [ ] Sans matière ou sans `fileId`, le panneau reste masqué.
+
+## Validation axe
+- [ ] Cliquer sur « Valider l'axe ».
+- [ ] Un événement `axis:validated` est émis avec `{ axis, invert, ts }`.
+- [ ] Un feedback visuel confirme la validation.
+
+## Start DFM
+- [ ] Tant que la matière ou l'axe sont manquants, le bouton « Analyser » est désactivé.
+- [ ] Quand tous les prérequis sont présents, un clic émet `dfm:start { file_id, material_profile_id, axis|null, invert }`.
+- [ ] Le bouton se met en état bloqué pendant l'appel.

--- a/frontend/events-bus.js
+++ b/frontend/events-bus.js
@@ -1,0 +1,25 @@
+// Simple publish/subscribe bus without external deps
+// Usage: import bus from "./events-bus.js";
+//        const unsubscribe = bus.subscribe('foo', payload => ...);
+//        bus.publish('foo', data);
+
+export function createEventBus() {
+  const listeners = new Map();
+
+  return {
+    subscribe(event, handler) {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event).add(handler);
+      return () => listeners.get(event)?.delete(handler);
+    },
+    publish(event, payload) {
+      listeners.get(event)?.forEach((handler) => handler(payload));
+    },
+    unsubscribe(event, handler) {
+      listeners.get(event)?.delete(handler);
+    }
+  };
+}
+
+const eventBus = createEventBus();
+export default eventBus;

--- a/server/dfm_api_blueprint_stub.py
+++ b/server/dfm_api_blueprint_stub.py
@@ -1,0 +1,27 @@
+"""Blueprint DFM stub pour préparation du backend."""
+
+from flask import Blueprint, jsonify, request
+
+
+dfm_bp = Blueprint("dfm", __name__, url_prefix="/api/dfm")
+
+
+@dfm_bp.post("/start")
+def start() -> tuple[dict, int]:
+    """Valide l'entrée et file l'analyse DFM."""
+    data = request.get_json(force=True) or {}
+    file_id = data.get("file_id")
+    material_profile_id = data.get("material_profile_id")
+
+    if not file_id or not material_profile_id:
+        return jsonify({"error": "file_id and material_profile_id requis"}), 400
+
+    job_id = "stub"
+    return jsonify({"job_id": job_id, "status": "queued"}), 202
+
+
+@dfm_bp.get("/status/<job_id>")
+def status(job_id: str) -> tuple[dict, int]:
+    """Renvoie l'état du job DFM."""
+    return jsonify({"job_id": job_id, "status": "queued"}), 200
+

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -4,6 +4,7 @@
  */
 
 import HeatmapLayer from "./modules/HeatmapLayer.js";
+import eventBus from "../../frontend/events-bus.js";
 
 // État global minimal pour la DFM
 if (typeof window !== 'undefined') {
@@ -103,7 +104,16 @@ class DFMOrchestrator {
     this.demouldAxis = null;
     this.currentAxis = 'AUTO';
     this.invert = false;
+    this.axisValidated = false;
+    this.axisSelection = null;
     this.initAxisPanel();
+    eventBus.subscribe('material:selected', payload => {
+      const profile = payload?.materialProfile ?? payload;
+      if (profile) {
+        window.CAD.materialProfile = profile;
+        this.setMaterialProfile(profile);
+      }
+    });
   }
 
   setState(next){
@@ -114,11 +124,11 @@ class DFMOrchestrator {
     this.fileId = id || null;
     const hidden = document.getElementById('fileId');
     if (hidden && hidden.type === 'hidden') hidden.value = this.fileId || '';
-    this.updateAxisPanelState?.();
+    this.refreshAxisState?.();
   }
   setMaterialProfile(p){
     this.materialProfile = p || null;
-    this.updateAxisPanelState?.();
+    this.refreshAxisState?.();
   }
   setDemouldAxis(a){
     const vec = axisToVector(a);
@@ -159,6 +169,7 @@ class DFMOrchestrator {
   initAxisPanel(){
     this.axisPanel = document.getElementById('dfmAxisPanel');
     if (!this.axisPanel) return;
+    this.axisPanel.style.display = 'none';
 
     this.axisButtons = {
       X: document.getElementById('axisXBtn'),
@@ -167,6 +178,7 @@ class DFMOrchestrator {
       AUTO: document.getElementById('axisAutoBtn')
     };
     this.invertToggle = document.getElementById('invertAxisToggle');
+    this.axisConfirmBtn = document.getElementById('axisConfirmBtn');
 
     Object.entries(this.axisButtons).forEach(([axis, btn])=>{
       if (!btn) return;
@@ -183,7 +195,27 @@ class DFMOrchestrator {
       });
     }
 
-    this.updateAxisPanelState();
+    if (this.axisConfirmBtn){
+      this.axisConfirmBtn.addEventListener('click', () => {
+        console.log('axis confirm before', { fileId: this.fileId, material: this.materialProfile });
+        if (!this.fileId || !this.materialProfile){
+          UI.info("Importez un fichier et validez la matière avant l’axe.");
+          return;
+        }
+        this.axisValidated = true;
+        this.axisSelection = {
+          axis: this.currentAxis,
+          invert: this.invert,
+          ts: Date.now()
+        };
+        this.setDemouldAxis({ axis: this.currentAxis, direction: this.invert ? -1 : 1 });
+        eventBus.publish('axis:validated', this.axisSelection);
+        this.axisConfirmBtn.textContent = 'Axe validé';
+        console.log('axis confirm after', this.axisSelection);
+      });
+    }
+
+    this.refreshAxisState();
   }
 
   updateAxisPanelState(){
@@ -194,42 +226,42 @@ class DFMOrchestrator {
     if (this.invertToggle) this.invertToggle.disabled = !enabled;
   }
 
-  async startDFM(){
+  refreshAxisState(){
+    const canShow = !!(this.fileId && this.materialProfile);
+    if (this.axisPanel) {
+      this.axisPanel.style.display = canShow ? 'block' : 'none';
+    }
+    this.updateAxisPanelState();
+  }
+
+  startDFM(){
     const fileId = this.fileId;
     const profile = this.materialProfile;
-    if (!fileId || !profile){
-      console.error("startDFM prérequis manquants", { fileId, profile });
-      UI.err("Fichier ou profil matière manquant");
+    if (!fileId){
+      UI.info("Importez un fichier avant d’analyser.");
+      console.warn("startDFM: fileId manquant");
+      return;
+    }
+    if (!profile){
+      UI.info("Sélectionnez une matière.");
+      console.warn("startDFM: matière manquante");
+      return;
+    }
+    if (!this.axisValidated){
+      UI.info("Validez l’axe de démoulage.");
+      console.warn("startDFM: axe non validé");
       return;
     }
 
     const payload = {
       file_id: fileId,
       material_profile_id: profile.id || profile.material_profile_id || profile,
-      axis: this.currentAxis,
-      invert: this.invert,
+      axis: this.axisSelection?.axis ?? null,
+      invert: this.axisSelection?.invert ?? false,
     };
 
-    try{
-      const res = await fetch("/api/dfm/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(payload)
-      });
-
-      if (!res.ok){
-        const txt = await res.text().catch(() => "");
-        console.error("startDFM erreur", res.status, txt);
-        UI.err("Lancement DFM impossible");
-        return;
-      }
-
-      const data = await res.json().catch(() => ({}));
-      console.log("DFM démarrée", data);
-    }catch(e){
-      console.error("startDFM réseau", e);
-      UI.err("Erreur réseau lors du lancement de la DFM");
-    }
+    console.log("dfm:start", payload);
+    eventBus.publish('dfm:start', payload);
   }
 
   // ---------------------- Analyse ----------------------
@@ -483,6 +515,31 @@ if (typeof window !== 'undefined') {
   window.DFMOrchestrator = dfmOrchestrator;
 }
 
+eventBus.subscribe('dfm:start', async (payload) => {
+  try {
+    const res = await fetch('/api/dfm/start', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload)
+    });
+
+    if (!res.ok) {
+      const msg = res.status === 404
+        ? 'endpoint introuvable'
+        : `Erreur ${res.status} ${res.statusText}`;
+      UI.err(msg);
+      console.error('dfm:start', msg);
+      return;
+    }
+
+    const data = await res.json().catch(() => ({}));
+    console.log('dfm:start response', data);
+  } catch (err) {
+    console.error('dfm:start network error', err);
+    UI.err('Erreur réseau');
+  }
+});
+
 // Expose startDFM globally for non-module callers
 if (typeof window !== 'undefined') {
   if (typeof window.DFMOrchestrator.startDFM === 'function') {
@@ -586,7 +643,7 @@ export function initDFMUI() {
     document.addEventListener('material:confirmed', e => {
       window.CAD.materialProfile = e.detail;
       dfmOrchestrator.setMaterialProfile(e.detail);
-      if (dfmOrchestrator.demouldAxis) {
+      if (dfmOrchestrator.demouldAxis && dfmOrchestrator.axisValidated) {
         dfmOrchestrator.startDFM();
       }
     });

--- a/templates/index.html
+++ b/templates/index.html
@@ -277,7 +277,6 @@
         <input type="hidden" id="fileId" value="">
       </button>
 
-      <div id="axisPickerInline" class="d-none"></div>
     </div>
 
     <!-- Outils 3D intégrés à ton UI (conservés, ids différents => main.js ne les utilise pas) -->
@@ -358,9 +357,6 @@
                                         <span id="injectionReadyText">En analyse...</span>
                                     </span>
                                 </div>
-                                <button id="changeDemoldingAxisBtn" class="btn btn-dfm-secondary me-2" style="display: none;">
-                                    <i class="bi bi-arrow-repeat me-2"></i>{% if current_language == 'en' %}Change axis{% else %}Changer axe{% endif %}
-                                </button>
                                 <button id="generatePdfBtn" class="btn btn-dfm-primary me-2" style="display: none;">
                                     <i class="bi bi-file-earmark-pdf me-2"></i>{% if current_language == 'en' %}PDF Report{% else %}Rapport PDF{% endif %}
                                 </button>


### PR DESCRIPTION
## Summary
- document DFM frontend events
- add minimal publish/subscribe event bus
- add QA checklists for axis gating, axis validation and DFM start
- introduce stub Flask blueprint for DFM API
- hide demould-axis panel until file and material are selected
- emit `axis:validated` with state updates and UI feedback
- enforce DFM start preconditions and publish `dfm:start` instead of fetching
- trigger `/api/dfm/start` on `dfm:start` with clear error handling
- register DFM API blueprint in app factory and log all routes
- remove obsolete axis modal markup to avoid ARIA warnings

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*
- `python` script importing app and POSTing to `/api/dfm/start` → `{'job_id': 'stub', 'status': 'queued'}`

------
https://chatgpt.com/codex/tasks/task_e_68bffd8fa0248333b42ffca76c11de7d