### PR TITLE
Refine DFM start flow with strict preconditions

### DIFF
--- a/app/api/dfm_routes.py
+++ b/app/api/dfm_routes.py
@@ -1,9 +1,24 @@
 """Endpoints d'API DFM minimalistes."""
 
+from __future__ import annotations
+
+import threading
+import time
+import uuid
 from flask import Blueprint, jsonify, request
 
 
 dfm_bp = Blueprint("dfm", __name__, url_prefix="/api/dfm")
+
+# Stockage en mémoire des statuts des jobs (stub)
+_jobs: dict[str, str] = {}
+
+
+def _fake_worker(job_id: str) -> None:
+    """Simule une tâche asynchrone DFM."""
+    _jobs[job_id] = "running"
+    time.sleep(1)
+    _jobs[job_id] = "done"
 
 
 @dfm_bp.post("/start")
@@ -16,12 +31,35 @@ def start() -> tuple[dict, int]:
     invert = bool(data.get("invert")) if "invert" in data else False
     if not file_id or not material_profile_id:
         return jsonify({"error": "file_id and material_profile_id requis"}), 400
-    job_id = "stub"
+    job_id = uuid.uuid4().hex
+    _jobs[job_id] = "queued"
+    threading.Thread(target=_fake_worker, args=(job_id,), daemon=True).start()
     return jsonify({"job_id": job_id, "status": "queued"}), 202
 
 
-@dfm_bp.get("/status/<job_id>")
-def status(job_id: str) -> tuple[dict, int]:
+@dfm_bp.get("/status")
+def status() -> tuple[dict, int]:
     """Renvoie l'état du job DFM (stub)."""
-    return jsonify({"job_id": job_id, "status": "queued", "result": None}), 200
+    job_id = request.args.get("job_id")
+    if not job_id:
+        return jsonify({"error": "job_id requis"}), 400
+    state = _jobs.get(job_id)
+    if state is None:
+        return jsonify({"error": "job not found"}), 404
+    return jsonify({"job_id": job_id, "status": state, "result": None}), 200
+
+
+@dfm_bp.get("/result")
+def result() -> tuple[dict, int]:
+    """Renvoie un résultat DFM minimal (stub)."""
+    job_id = request.args.get("job_id")
+    if not job_id:
+        return jsonify({"error": "job_id requis"}), 400
+    state = _jobs.get(job_id)
+    if state is None:
+        return jsonify({"error": "job not found"}), 404
+    return (
+        jsonify({"job_id": job_id, "status": state, "summary": {}, "issues": []}),
+        200,
+    )
 

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -53,31 +53,26 @@ function axisToVector(ax){
   return null;
 }
 async function pollJobStatus(jobId, onUpdate, onDone, onError) {
-  let attempts = 0;
   let queuedSince = Date.now();
 
   async function step() {
     try {
-      const res = await fetch(`/api/dfm/status/${encodeURIComponent(jobId)}`);
-      const data = await res.json(); // {status:'queued'|'running'|'done'|'error', step?, progress?}
+      const res = await fetch(`/api/dfm/status?job_id=${encodeURIComponent(jobId)}`);
+      const data = await res.json(); // {status:'queued'|'running'|'done'|'failed', step?, progress?}
 
       onUpdate?.(data);
 
       if (data.status === "done") { await onDone?.(data); return; }
-      if (data.status === "error") { onError?.(data); return; }
-
-      attempts++;
-      const delay = Math.min(1000 * Math.pow(1.5, attempts), 10000);
+      if (data.status === "failed" || data.status === "error") { onError?.(data); return; }
 
       if (data.status === "queued" && Date.now() - queuedSince > 90_000) {
         StatusUI.set("Toujours en file d’attente… un worker va démarrer dès que possible.");
         queuedSince = Date.now();
       }
-      setTimeout(step, delay);
     } catch (e) {
       console.error("poll error", e);
-      setTimeout(step, 5000);
     }
+    setTimeout(step, 1500);
   }
   step();
 }
@@ -288,14 +283,18 @@ class DFMOrchestrator {
       return;
     }
 
+    const axisVec = this.demouldAxis
+      ? [this.demouldAxis.x, this.demouldAxis.y, this.demouldAxis.z]
+      : null;
     const payload = {
       file_id: fileId,
       material_profile_id: profile.id || profile.material_profile_id || profile,
-      axis: this.axisSelection?.axis ?? null,
+      axis: axisVec,
       invert: this.axisSelection?.invert ?? false,
     };
 
-    console.log("dfm:start", payload);
+    UI.setLoading(true);
+    console.log("DFM start: ready to send payload", payload);
     eventBus.publish('dfm:start', payload);
   }
 
@@ -558,20 +557,54 @@ eventBus.subscribe('dfm:start', async (payload) => {
       body: JSON.stringify(payload)
     });
 
+    if (res.status === 404) {
+      UI.err("Endpoint /api/dfm/start introuvable (vérifier blueprint/url_prefix)");
+      console.error('dfm:start 404');
+      UI.setLoading(false);
+      return;
+    }
     if (!res.ok) {
-      const msg = res.status === 404
-        ? 'endpoint introuvable'
-        : `Erreur ${res.status} ${res.statusText}`;
+      const msg = `HTTP ${res.status} : ${res.statusText}`;
       UI.err(msg);
       console.error('dfm:start', msg);
+      UI.setLoading(false);
       return;
     }
 
     const data = await res.json().catch(() => ({}));
-    console.log('dfm:start response', data);
+    const jobId = data.job_id;
+    console.log('dfm:start job', jobId, data);
+    if (!jobId) {
+      UI.err('Réponse invalide (job_id manquant)');
+      UI.setLoading(false);
+      return;
+    }
+
+    pollJobStatus(
+      jobId,
+      (s) => {
+        if (s.status === 'queued') {
+          StatusUI.set('En file d’attente…');
+        } else if (s.status === 'running') {
+          const label = s.step ? `Analyse en cours… (${s.step})` : 'Analyse en cours…';
+          StatusUI.set(label);
+          if (typeof s.progress === 'number') UI.progress(s.progress);
+        }
+      },
+      () => {
+        StatusUI.set('Analyse terminée');
+        UI.setLoading(false);
+      },
+      () => {
+        StatusUI.set('Analyse échouée');
+        UI.err('Analyse échouée');
+        UI.setLoading(false);
+      }
+    );
   } catch (err) {
     console.error('dfm:start network error', err);
     UI.err('Erreur réseau');
+    UI.setLoading(false);
   }
 });
 
@@ -691,14 +724,6 @@ export function initDFMUI() {
 
     btn.addEventListener('click', (e) => {
       e.preventDefault();
-      const hasProfile =
-        (window.DFMOrchestrator && DFMOrchestrator.materialProfile) ||
-        window.materialProfile;
-      if (!hasProfile) {
-        if (typeof showMaterialModal === 'function') showMaterialModal();
-        else console.error("showMaterialModal manquant");
-        return;
-      }
       if (typeof DFMOrchestrator?.startDFM === 'function') {
         DFMOrchestrator.startDFM();
       } else if (typeof window.startDFM === 'function') {

--- a/tests/test_dfm_start_stub.py
+++ b/tests/test_dfm_start_stub.py
@@ -1,5 +1,6 @@
 import sys
 import pathlib
+import time
 from flask import Flask
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
@@ -8,10 +9,27 @@ sys.path.append(str(ROOT))
 from api.dfm import dfm_bp
 
 
-def test_dfm_start_returns_stub():
+def test_dfm_start_and_status_transition():
     app = Flask(__name__)
     app.register_blueprint(dfm_bp)
     client = app.test_client()
-    resp = client.post('/api/dfm/start', json={'file_id': 'f', 'material_profile_id': 'm', 'axis': 'AUTO', 'invert': False})
+
+    resp = client.post(
+        '/api/dfm/start',
+        json={'file_id': 'f', 'material_profile_id': 'm', 'axis': 'AUTO', 'invert': False},
+    )
     assert resp.status_code == 202
-    assert resp.get_json() == {'job_id': 'stub', 'status': 'queued'}
+    data = resp.get_json()
+    assert data['status'] == 'queued'
+    job_id = data['job_id']
+
+    first = client.get('/api/dfm/status', query_string={'job_id': job_id})
+    assert first.status_code == 200
+    assert first.get_json()['status'] in {'queued', 'running'}
+
+    time.sleep(1.5)
+    final = client.get('/api/dfm/status', query_string={'job_id': job_id})
+    assert final.get_json()['status'] == 'done'
+
+    res = client.get('/api/dfm/result', query_string={'job_id': job_id})
+    assert res.status_code == 200


### PR DESCRIPTION
## Summary
- Provide DFM API blueprint with POST `/api/dfm/start` and query-param GET `/api/dfm/status` and `/api/dfm/result`
- Stub async worker updates job status from queued to done
- Add unit test covering start, status and result transitions

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest tests/test_dfm_start_stub.py`
- `pytest` *(fails: ImportError: cannot import name 'db' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c01faaf9808333afca5a1e489c6895