### PR TITLE
Assure ouverture modale matière

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -78,10 +78,19 @@ async function pollJobStatus(jobId, onUpdate, onDone, onError) {
 }
 
 export function showMaterialModal() {
-  if (!window.bootstrap) { console.error("Bootstrap non chargé"); return; }
-  const el = document.getElementById('materialQuestionnaireModal');
-  if (!el) { console.error("#materialQuestionnaireModal introuvable"); return; }
-  const modal = new bootstrap.Modal(el, { backdrop: 'static' });
+  if (!window.bootstrap) {
+    console.error("Bootstrap non chargé");
+    return;
+  }
+  const el =
+    document.getElementById("materialQuestionnaireModal") ||
+    document.getElementById("materialModal") ||
+    document.querySelector("[data-material-modal]");
+  if (!el) {
+    console.error("Modal matière introuvable");
+    return;
+  }
+  const modal = bootstrap.Modal.getOrCreateInstance(el, { backdrop: "static" });
   modal.show();
 }
 
@@ -794,7 +803,12 @@ if (typeof window !== 'undefined' && typeof document !== 'undefined') {
 function dfmSelfCheck() {
   const errors = [];
   if (!window.bootstrap || !bootstrap.Modal) errors.push("bootstrap.Modal absent");
-  if (!document.getElementById('materialQuestionnaireModal')) errors.push("#materialQuestionnaireModal absent");
+  if (!(
+    document.getElementById("materialQuestionnaireModal") ||
+    document.getElementById("materialModal") ||
+    document.querySelector("[data-material-modal]")
+  ))
+    errors.push("modal matière absent");
   if (!document.getElementById('analyzeBtn')) errors.push("#analyzeBtn absent");
 
   if (errors.length) {

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -258,11 +258,16 @@ function onAnalyseClick(e) {
   document.dispatchEvent(
     new CustomEvent("material:confirmed", { detail: res.payload })
   );
-  const modalEl = document.getElementById("materialQuestionnaireModal");
+  const modalEl =
+    document.getElementById("materialQuestionnaireModal") ||
+    document.getElementById("materialModal") ||
+    document.querySelector("[data-material-modal]");
   if (modalEl) {
     bootstrap.Modal.getInstance(modalEl)?.hide();
-    document.querySelectorAll('.modal-backdrop').forEach(el => el.remove());
-    document.body.classList.remove('modal-open');
+    document
+      .querySelectorAll(".modal-backdrop")
+      .forEach((el) => el.remove());
+    document.body.classList.remove("modal-open");
   }
 }
 


### PR DESCRIPTION
## Résumé
- cherche dynamiquement le bon modal matière (#materialQuestionnaireModal, #materialModal ou attribut `data-material-modal`)
- utilise `bootstrap.Modal.getOrCreateInstance` pour garantir l'ouverture
- ferme le modal détecté et auto-vérifie sa présence

## Tests
- `pytest` *(erreurs d'import db et autres modules)*
- `npm run test:e2e tests-e2e/modal-material.spec.ts` *(échec : Process from config.webServer was not able to start)*

------
https://chatgpt.com/codex/tasks/task_e_68c0328c31748333aca308f399c69069