### PR TITLE
Refactor analysis trigger into orchestrator handler

### DIFF
--- a/docs/DFM_EVENTS.md
+++ b/docs/DFM_EVENTS.md
@@ -14,15 +14,13 @@ Payload :
 
 Émis lors de la validation de la modale matière.
 
-## `axis:validated`
+## `axis:confirmed`
 
 Payload :
 
 ```json
 {
-  "axis": [x, y, z],
-  "invert": bool,
-  "ts": 1234567890
+  "axis": [x, y, z]
 }
 ```
 

--- a/docs/QA_CHECKS_AXIS_AND_MATERIAL.md
+++ b/docs/QA_CHECKS_AXIS_AND_MATERIAL.md
@@ -7,7 +7,7 @@
 
 ## Validation axe
 - [ ] Cliquer sur « Valider l'axe ».
-- [ ] Un événement `axis:validated` est émis avec `{ axis, invert, ts }`.
+- [ ] Un événement `axis:confirmed` est émis avec `{ axis }`.
 - [ ] Un feedback visuel confirme la validation.
 
 ## Start DFM

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -83,13 +83,13 @@ function showMaterialModal() {
     return;
   }
   const el =
-    document.getElementById("materialQuestionnaireModal") ||
     document.getElementById("materialModal") ||
     document.querySelector("[data-material-modal]");
   if (!el) {
     console.error("Modal matière introuvable");
     return;
   }
+  console.debug("ouverture modale matière");
   const modal = bootstrap.Modal.getOrCreateInstance(el, { backdrop: "static" });
   modal.show();
 }
@@ -110,19 +110,19 @@ class DFMOrchestrator {
     this.invert = false;
     this.axisValidated = false;
     this.axisSelection = null;
+    this.selectedAxis = null;
     this.axisPanel = null;
     this.axisPanelInitialized = false;
     this.initAxisPanel();
-    eventBus.subscribe('material:selected', payload => {
-      const profile = payload?.materialProfile ?? payload;
-      if (profile) {
-        window.CAD.materialProfile = profile;
-        this.setMaterialProfile(profile);
-      }
-    });
-    eventBus.subscribe('axis:validated', payload => {
-      this.axisValidated = true;
-      this.axisSelection = payload || this.axisSelection;
+  }
+
+  init(){
+    // Binding en JS pour éviter l'attribut onclick inline
+    document.getElementById('analyzeBtn')?.addEventListener('click', () => this.handleAnalyzeClick());
+    window.addEventListener('material:selected', (e) => {
+      this.materialProfile = e.detail.materialProfile;
+      window.CAD.materialProfile = this.materialProfile;
+      this.showAxisPicker();
     });
   }
 
@@ -250,7 +250,8 @@ class DFMOrchestrator {
           ts: Date.now()
         };
         this.setDemouldAxis({ axis: this.currentAxis, direction: this.invert ? -1 : 1 });
-        eventBus.publish('axis:validated', this.axisSelection);
+        const vec = this.demouldAxis;
+        window.dispatchEvent(new CustomEvent('axis:confirmed', { detail: { axis: vec } }));
         this.axisConfirmBtn.innerHTML = 'Axe validé <span class="ms-1">✅</span>';
         this.axisConfirmBtn.classList.remove('btn-primary');
         this.axisConfirmBtn.classList.add('btn-success');
@@ -277,55 +278,38 @@ class DFMOrchestrator {
     this.updateAxisPanelState();
   }
 
-  checkPrereqs(){
-    if (!this.fileId) return "file";
-    if (!this.materialProfile) return "material";
-    if (!this.axisValidated) return "axis";
-    return "ok";
+
+  handleAnalyzeClick(){
+    if (!this.fileId){
+      UI.info("Importe un STEP");
+      const zone = document.getElementById('uploadArea') || document.getElementById('dropzone');
+      if (zone){
+        zone.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        zone.classList.add('pulse');
+        setTimeout(()=>zone.classList.remove('pulse'), 1500);
+      }
+      return;
+    }
+    if (!this.materialProfile){
+      showMaterialModal();
+      return;
+    }
+    this.showAxisPicker();
   }
 
-  onAnalyzeClick(e){
-    e?.preventDefault?.();
-    const missing = this.checkPrereqs();
-    switch (missing){
-      case "file": {
-        UI.info("Importe un STEP");
-        const zone = document.getElementById('uploadArea') || document.getElementById('dropzone');
-        if (zone){
-          zone.scrollIntoView({ behavior: 'smooth', block: 'center' });
-          zone.classList.add('pulse');
-          setTimeout(()=>zone.classList.remove('pulse'), 1500);
-        }
-        return;
-      }
-      case "material": {
-        const off = eventBus.subscribe('material:selected', () => {
-          off();
-          setTimeout(()=>{
-            this.axisPanel?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-            this.axisPanel?.classList.add('pulse');
-            setTimeout(()=>this.axisPanel?.classList.remove('pulse'), 1500);
-          },0);
-        });
-        showMaterialModal();
-        return;
-      }
-      case "axis": {
-        this.axisPanel?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-        this.axisPanel?.classList.add('pulse');
-        setTimeout(()=>this.axisPanel?.classList.remove('pulse'), 1500);
-        return;
-      }
-      case "ok":
-        console.info('startDFM guard OK', {
-          fileId: this.fileId,
-          materialProfile: this.materialProfile,
-          axisValidated: this.axisValidated,
-        });
-        UI.setLoading(true);
-        this.startDFM();
-        return;
-    }
+  showAxisPicker(){
+    this.axisPanel?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    this.axisPanel?.classList.add('pulse');
+    setTimeout(()=>this.axisPanel?.classList.remove('pulse'), 1500);
+
+    if (this._axisUnsub) this._axisUnsub();
+    const handler = (e) => {
+      this._axisUnsub();
+      this.selectedAxis = e.detail.axis;
+      this.startAnalysis({ fileId: this.fileId, materialProfile: this.materialProfile, axis: this.selectedAxis });
+    };
+    this._axisUnsub = () => window.removeEventListener('axis:confirmed', handler);
+    window.addEventListener('axis:confirmed', handler);
   }
 
   startDFM(){
@@ -366,7 +350,7 @@ class DFMOrchestrator {
   async startAnalysis({
     fileId = this.fileId,
     materialProfile = this.materialProfile,
-    demouldAxis = this.demouldAxis
+    axis = this.demouldAxis
   } = {}) {
     if (!this.materialProfile) {
       console.warn("Aucun profil matière sélectionné, ouverture de la modale.");
@@ -407,20 +391,20 @@ class DFMOrchestrator {
       this.handleError?.("file_missing");
       return;
     }
-    if (!demouldAxis || !this.axisValidated) {
+    if (!axis) {
       UI.info("Veuillez valider l’axe de démoulage.");
       this.handleError?.("axe_manquant");
       return;
     }
 
-    dbg("startAnalysis", { fileId, materialProfile, demouldAxis });
+    dbg("startAnalysis", { fileId, materialProfile, axis });
     this.setState(DFM_STATES.RUNNING);
     this._renderLoading();
     UI.setLoading(true);
 
     const payload = {
       file_id: fileId,
-      axis: demouldAxis,
+      axis,
       material_profile: materialProfile?.resin || "GENERIC",
     };
     console.debug("[DFM] start payload", payload);
@@ -608,9 +592,9 @@ class DFMOrchestrator {
   }
 }
 
-const dfmOrchestrator = (typeof window !== 'undefined' && window.DFMOrchestrator) ? window.DFMOrchestrator : new DFMOrchestrator();
+const orchestrator = (typeof window !== 'undefined' && window.DFMOrchestrator) ? window.DFMOrchestrator : new DFMOrchestrator();
 if (typeof window !== 'undefined') {
-  window.DFMOrchestrator = dfmOrchestrator;
+  window.DFMOrchestrator = orchestrator;
 }
 
 eventBus.subscribe('dfm:start', async (payload) => {
@@ -764,43 +748,22 @@ function initDFMUI() {
   }
 
   document.addEventListener("DOMContentLoaded", () => {
-    dfmOrchestrator.setFileId(window.CAD.fileIdStep);
-    dfmOrchestrator.setMaterialProfile(window.CAD.materialProfile);
+    orchestrator.setFileId(window.CAD.fileIdStep);
+    orchestrator.setMaterialProfile(window.CAD.materialProfile);
 
     window.addEventListener('dfm:fileReady', e => {
       window.CAD.fileIdStep = e.detail.fileId;
-      dfmOrchestrator.setFileId(e.detail.fileId);
+      orchestrator.setFileId(e.detail.fileId);
     });
 
-    document.addEventListener('material:confirmed', e => {
-      window.CAD.materialProfile = e.detail;
-      dfmOrchestrator.setMaterialProfile(e.detail);
-      if (dfmOrchestrator.demouldAxis && dfmOrchestrator.axisValidated) {
-        dfmOrchestrator.startDFM();
-      }
-    });
-  });
-
-  document.addEventListener('DOMContentLoaded', () => {
-    const btn = document.getElementById('analyzeBtn');
-    if (!btn || btn.dataset.bound) return;
-    btn.dataset.bound = "1";
-
-    btn.addEventListener('click', (e) => {
-      if (typeof DFMOrchestrator?.onAnalyzeClick === 'function') {
-        DFMOrchestrator.onAnalyzeClick(e);
-      } else {
-        e.preventDefault();
-        console.error("onAnalyzeClick introuvable");
-      }
-    });
+    orchestrator.init();
   });
 }
 
 if (typeof window !== 'undefined') {
   window.showMaterialModal = showMaterialModal;
   window.DFM_STATES = DFM_STATES;
-  window.dfmOrchestrator = dfmOrchestrator;
+  window.dfmOrchestrator = orchestrator;
   window.collectMaterialForm = collectMaterialForm;
   window.initDFMUI = initDFMUI;
 }
@@ -812,7 +775,6 @@ function dfmSelfCheck() {
   const errors = [];
   if (!window.bootstrap || !bootstrap.Modal) errors.push("bootstrap.Modal absent");
   if (!(
-    document.getElementById("materialQuestionnaireModal") ||
     document.getElementById("materialModal") ||
     document.querySelector("[data-material-modal]")
   ))
@@ -828,4 +790,9 @@ function dfmSelfCheck() {
 
 if (typeof window !== 'undefined' && typeof document !== 'undefined') {
   window.requestAnimationFrame(dfmSelfCheck);
+}
+
+// Legacy global for older templates still calling onclick="onAnalyzeClick()"
+if (typeof window !== 'undefined') {
+  window.onAnalyzeClick = () => orchestrator.handleAnalyzeClick();
 }

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -1,7 +1,7 @@
 // Logiciel de sélection des critères matière
 // Applique les règles exclusives, conflits et limites puis gère le bouton "Analyser".
 
-import eventBus from "./modules/events-bus.js";
+// Pas d'inline onclick : tout est câblé en JS
 
 // === Déclaration des règles métiers ===
 const RULES = {
@@ -130,7 +130,7 @@ function updateSummary() {
   if (summary) {
     summary.textContent = `✅ Valides: ${valids.length} | ⚠️ Avertissements: ${state.warnings.size} | ⛔ Blocants: ${state.blockers.size}`;
   }
-  const btn = document.getElementById("submitQuestionnaire");
+  const btn = document.getElementById("materialConfirmBtn");
   if (btn) btn.disabled = state.blockers.size > 0;
 }
 
@@ -238,7 +238,9 @@ function validateForm() {
   };
 }
 
-function onAnalyseClick(e) {
+let materialModal;
+
+function onMaterialConfirm(e) {
   const res = validateForm();
   if (!res.ok) {
     e.preventDefault();
@@ -247,32 +249,26 @@ function onAnalyseClick(e) {
     first?.focus();
     return;
   }
-  // Diffuse un profil matière synthétique (id/slug + critères) sur le bus
   const profile = {
     id: res.payload?.[0] || "custom",
     slug: res.payload?.[0] || "custom",
     criteria: res.payload,
   };
-  eventBus.publish("material:selected", { materialProfile: profile });
-  // Événement legacy pour compatibilité
-  document.dispatchEvent(
-    new CustomEvent("material:confirmed", { detail: res.payload })
+  console.debug("validation matière", profile);
+  window.dispatchEvent(
+    new CustomEvent("material:selected", { detail: { materialProfile: profile } })
   );
-  const modalEl =
-    document.getElementById("materialQuestionnaireModal") ||
-    document.getElementById("materialModal") ||
-    document.querySelector("[data-material-modal]");
-  if (modalEl) {
-    bootstrap.Modal.getInstance(modalEl)?.hide();
-    document
-      .querySelectorAll(".modal-backdrop")
-      .forEach((el) => el.remove());
-    document.body.classList.remove("modal-open");
-  }
+  console.debug("event material:selected émis", profile);
+  materialModal?.hide();
 }
 
 // === Initialisation ===
 document.addEventListener("DOMContentLoaded", () => {
+  const el = document.getElementById("materialModal");
+  if (el && window.bootstrap?.Modal) {
+    materialModal = bootstrap.Modal.getOrCreateInstance(el, { backdrop: "static" });
+  }
+
   document.querySelectorAll(".criterion").forEach((cb) => {
     cb.addEventListener("change", (e) => {
       const el = e.target;
@@ -288,8 +284,8 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   document
-    .getElementById("submitQuestionnaire")
-    ?.addEventListener("click", onAnalyseClick);
+    .getElementById("materialConfirmBtn")
+    ?.addEventListener("click", onMaterialConfirm);
 
   evaluate();
 });

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -263,7 +263,7 @@ if (typeof collectMaterialForm !== 'function') {
 (function bindDFMAfterMaterial(){
   if (window.__cadlyticsDFMChained) return;
   window.__cadlyticsDFMChained = true;
-  document.addEventListener('material:confirmed', () => {
+  window.addEventListener('material:selected', () => {
     window.state = window.state || {};
     if (window.state.fileLoaded && window.state.materialProfile) {
       if (typeof window.runDFM === 'function') {

--- a/templates/index.html
+++ b/templates/index.html
@@ -435,11 +435,11 @@
     </div>
 
     <!-- Modal questionnaire matériaux -->
-    <div class="modal fade" id="materialQuestionnaireModal" tabindex="-1" aria-labelledby="materialQuestionnaireModalLabel">
+    <div class="modal fade" id="materialModal" tabindex="-1" aria-labelledby="materialModalLabel">
         <div class="modal-dialog modal-lg">
             <div class="modal-content">
                 <div class="modal-header">
-                    <h5 class="modal-title" id="materialQuestionnaireModalLabel">
+                    <h5 class="modal-title" id="materialModalLabel">
                         <i class="bi bi-clipboard-check me-2"></i>Questionnaire de sélection matériaux
                     </h5>
                     <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
@@ -708,7 +708,7 @@
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>
-                    <button type="button" class="btn btn-primary" id="submitQuestionnaire">
+                    <button type="button" class="btn btn-primary" id="materialConfirmBtn">
                         <i class="bi bi-check-circle me-2"></i>Analyser et recommander
                     </button>
                 </div>

--- a/tests-e2e/modal-material.spec.ts
+++ b/tests-e2e/modal-material.spec.ts
@@ -6,10 +6,10 @@ test('Ouverture et fermeture du modal matière', async ({ page }) => {
   await expect(analyze).toBeVisible();
 
   await analyze.click();
-  const modal = page.locator('#materialQuestionnaireModal.show, .modal.show:has(#materialQuestionnaireModal)');
+  const modal = page.locator('#materialModal.show, .modal.show:has(#materialModal)');
   await expect(modal).toBeVisible();
 
   await modal.getByRole('button', { name: 'Annuler' }).click();
 
-  await expect(page.locator('#materialQuestionnaireModal.show')).toHaveCount(0);
+  await expect(page.locator('#materialModal.show')).toHaveCount(0);
 });


### PR DESCRIPTION
## Summary
- handle analyse button click within DFMOrchestrator
- avoid inline onclick and expose legacy `onAnalyzeClick` proxy
- standardize material modal IDs and dispatch `material:selected`
- start analysis only after axis picker emits `axis:confirmed`
- expose `onAnalyzeClick` global at end of orchestrator for legacy templates

## Testing
- `npm test` (fails: Error: no test specified)
- `pytest` (fails: ImportError: cannot import name 'db')
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c116078a6483338640b9ce7ae599a9