### PR TITLE
Gate axis selection on material approval

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,14 @@ Le fichier converti est accessible via :
 ```
 http://localhost:5000/uploads/<uuid>.xkt
 ```
+
+## QA rapide
+
+1. **Upload STEP** : noter `file_id` dans la console et vérifier `GET /api/debug/file/<file_id>` → `step_path` existant.
+2. **Analyser sans matière** : clique sur *Analyser* ouvre la modale matière, aucune requête POST.
+3. **Matière validée** : le panneau d’axe apparaît sous le viewer.
+4. **Axe validé** : POST `/api/dfm/start` (JSON) avec `file_id`, `material_profile_id`, `axis`, `invert`; attendre `202` + `{job_id}` puis poller.
+5. **Serveur** : `tasks.dfm.dfm_run` utilise `Storage.get_step_path(file_id)` puis `dfm_analyzer.run_dfm(step_path=…)`.
+6. **XKT** : uniquement pour le viewer et les vues 3D, jamais pour les métriques.
+7. **Erreurs** : `file_id` inconnu, `material_profile_id` absent ou `axis` manquant → message d’erreur clair.
+

--- a/app/api/dfm_routes.py
+++ b/app/api/dfm_routes.py
@@ -2,47 +2,81 @@
 
 from __future__ import annotations
 
-import threading
-import time
-import uuid
 from flask import Blueprint, jsonify, request
+from celery.result import AsyncResult
+from tasks.dfm import dfm_run
+from app.storage.storage import Storage
+from app.material_profiles import get_profile
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 dfm_bp = Blueprint("dfm", __name__, url_prefix="/api/dfm")
 
-# Stockage en mémoire des statuts des jobs (stub)
+# Stockage en mémoire des statuts des jobs (fallback)
 _jobs: dict[str, str] = {}
 
 
-def _fake_worker(job_id: str) -> None:
-    """Simule une tâche asynchrone DFM."""
-    _jobs[job_id] = "running"
-    time.sleep(1)
-    _jobs[job_id] = "done"
+_CELERY_STATES = {
+    "PENDING": "queued",
+    "STARTED": "running",
+    "PROGRESS": "running",
+    "SUCCESS": "done",
+    "FAILURE": "failed",
+}
+
+
+def _map_state(state: str) -> str:
+    return _CELERY_STATES.get(state, state.lower())
 
 
 @dfm_bp.post("/start")
 def start() -> tuple[dict, int]:
-    """Valide l'entrée et file l'analyse DFM (stub)."""
+    """Valide l'entrée et enfile la tâche Celery d'analyse DFM."""
     data = request.get_json(silent=True) or {}
     file_id = data.get("file_id")
     material_profile_id = data.get("material_profile_id")
     axis = data.get("axis")
     invert = bool(data.get("invert")) if "invert" in data else False
-    if not file_id or not material_profile_id:
-        return jsonify({"error": "file_id and material_profile_id requis"}), 400
-    job_id = uuid.uuid4().hex
-    _jobs[job_id] = "queued"
-    threading.Thread(target=_fake_worker, args=(job_id,), daemon=True).start()
-    return jsonify({"job_id": job_id, "status": "queued"}), 202
+    step_path = None
+    if file_id:
+        try:
+            step_path = Storage.get_step_path(file_id)
+        except FileNotFoundError:
+            step_path = None
+    logger.info("/api/dfm/start file_id=%s step_path=%s", file_id, step_path)
+    if not file_id or not material_profile_id or not axis:
+        return (
+            jsonify({"error": "file_id, material_profile_id et axis requis"}),
+            400,
+        )
+    if not get_profile(material_profile_id):
+        return jsonify({"error": "unknown_material_profile"}), 400
+    job = dfm_run.delay(
+        file_id=file_id,
+        material_profile_id=material_profile_id,
+        axis=axis,
+        invert=invert,
+    )
+    _jobs[job.id] = "queued"
+    return jsonify({"job_id": job.id, "status": "queued"}), 202
 
 
 @dfm_bp.get("/status")
 def status() -> tuple[dict, int]:
-    """Renvoie l'état du job DFM (stub)."""
+    """Renvoie l'état du job DFM."""
     job_id = request.args.get("job_id")
     if not job_id:
         return jsonify({"error": "job_id requis"}), 400
+    res = AsyncResult(job_id)
+    if res.state != "PENDING" or job_id in _jobs:
+        status = _map_state(res.state)
+        if res.state == "FAILURE":
+            error = str(res.info)
+            return jsonify({"job_id": job_id, "status": status, "error": error}), 200
+        meta = res.info if isinstance(res.info, dict) else None
+        return jsonify({"job_id": job_id, "status": status, "result": meta}), 200
     state = _jobs.get(job_id)
     if state is None:
         return jsonify({"error": "job not found"}), 404
@@ -51,10 +85,28 @@ def status() -> tuple[dict, int]:
 
 @dfm_bp.get("/result")
 def result() -> tuple[dict, int]:
-    """Renvoie un résultat DFM minimal (stub)."""
+    """Renvoie le résultat du job DFM."""
     job_id = request.args.get("job_id")
     if not job_id:
         return jsonify({"error": "job_id requis"}), 400
+    res = AsyncResult(job_id)
+    if res.state != "PENDING" or job_id in _jobs:
+        status = _map_state(res.state)
+        if res.state == "FAILURE":
+            error = str(res.info)
+            return (
+                jsonify({"job_id": job_id, "status": status, "summary": {}, "issues": [], "error": error}),
+                200,
+            )
+        if res.state == "SUCCESS" and isinstance(res.result, dict):
+            summary = res.result.get("summary", {})
+            issues = res.result.get("issues", [])
+        else:
+            summary, issues = {}, []
+        return (
+            jsonify({"job_id": job_id, "status": status, "summary": summary, "issues": issues}),
+            200,
+        )
     state = _jobs.get(job_id)
     if state is None:
         return jsonify({"error": "job not found"}), 404
@@ -62,4 +114,5 @@ def result() -> tuple[dict, int]:
         jsonify({"job_id": job_id, "status": state, "summary": {}, "issues": []}),
         200,
     )
+
 

--- a/app/dfm/dfm_analyzer.py
+++ b/app/dfm/dfm_analyzer.py
@@ -28,9 +28,11 @@ def run_dfm(
         logger.info("dfm %s dt=%.2fs rss=%.1fMB", step, time.perf_counter() - start_t, mem)
 
     t = time.perf_counter()
-    if not os.path.exists(input.step_path):
-        raise ValueError("STEP file not found")
-    with open(input.step_path, "r", errors="ignore") as fh:
+    # step_path is mandatory for any DFM analysis; do not fall back to XKT
+    step_path = input.get("step_path") if isinstance(input, dict) else getattr(input, "step_path", None)
+    if not step_path or not os.path.isfile(step_path):
+        raise ValueError("step_path_required")
+    with open(step_path, "r", errors="ignore") as fh:
         head = fh.read(64)
         if "ISO-10303" not in head and "STEP" not in head:
             raise ValueError("invalid_step")
@@ -46,10 +48,11 @@ def run_dfm(
         "volume": 0.0,
         "surface_area": 0.0,
     }
-    stl_path = None
+    stl_path = input.get("stl_path") if isinstance(input, dict) else getattr(input, "stl_path", None)
+    generated_stl = False
     try:  # optional CadQuery usage
         import cadquery as cq  # lazy import
-        workplane = cq.importers.importStep(input.step_path)
+        workplane = cq.importers.importStep(step_path)
         shape = workplane.val()
         bbox = shape.BoundingBox()
         metrics = {
@@ -57,9 +60,11 @@ def run_dfm(
             "volume": shape.Volume(),
             "surface_area": shape.Area(),
         }
-        stl_fd, stl_path = tempfile.mkstemp(suffix=".stl")
-        os.close(stl_fd)
-        cq.exporters.export(workplane, stl_path)
+        if not stl_path:
+            stl_fd, stl_path = tempfile.mkstemp(suffix=".stl")
+            os.close(stl_fd)
+            cq.exporters.export(workplane, stl_path)
+            generated_stl = True
     except Exception:
         pass
     if progress_cb:
@@ -67,19 +72,20 @@ def run_dfm(
     _log("metrics", t)
 
     from generate_3d_view import generate_view_data
-    out_dir = os.path.join("static", "dfm", input.file_id)
+    file_id = input.get("file_id") if isinstance(input, dict) else getattr(input, "file_id")
+    out_dir = os.path.join("static", "dfm", file_id)
     t = time.perf_counter()
     camera_states, heatmap_faces = generate_view_data(
-        stl_path, input.file_id, progress_cb, fast_mode=fast_mode
+        stl_path, file_id, progress_cb, fast_mode=fast_mode
     )
     _log("views_heatmap", t)
 
     from generate_thumbnails import generate_thumbnails
     t = time.perf_counter()
-    thumbnails = generate_thumbnails(input.step_path, out_dir)
+    thumbnails = generate_thumbnails(step_path, out_dir)
     _log("thumbnails", t)
 
-    if stl_path and os.path.exists(stl_path):
+    if generated_stl and stl_path and os.path.exists(stl_path):
         os.remove(stl_path)
 
     views = {"camera_states": camera_states, "thumbnails": thumbnails}

--- a/app/material_profiles.py
+++ b/app/material_profiles.py
@@ -1,0 +1,13 @@
+"""Material profile lookup table."""
+from app.dfm.interfaces import MaterialProfile
+
+_MATERIALS = {
+    "ABS": 1.0,
+    "GENERIC": 1.0,
+}
+
+def get_profile(material_id: str) -> MaterialProfile | None:
+    deg = _MATERIALS.get((material_id or "").upper())
+    if deg is None:
+        return None
+    return MaterialProfile(id=material_id, draft_min_deg=deg)

--- a/src/main.js
+++ b/src/main.js
@@ -423,11 +423,16 @@ async function convertAndGetXKT(files) {
   let fileId = data.file_id
             || deriveIdFromUrl(data.url)
             || deriveIdFromUrl(data.xktUrl);
-
+  const existing = window.CADLYTICS?.current?.fileId;
+  if (existing && fileId && existing !== fileId) {
+    console.warn(`[convert] file_id mismatch: keeping ${existing}, ignoring ${fileId}`);
+    fileId = existing;
+  }
+  if (!existing && fileId) {
+    exposeFileId(fileId);
+  }
   if (!fileId) {
     console.warn("[convert] pas de file_id ni dérivable", data);
-  } else {
-    exposeFileId(fileId);
   }
 
   return xktUrl;

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -102,7 +102,13 @@ const DFM_STATES = {
 
 class DFMOrchestrator {
   constructor(){
-    this.state = DFM_STATES.IDLE;
+    this.phase = DFM_STATES.IDLE;
+    this.state = this.state || {
+      fileLoaded: false,
+      materialSelected: false,
+      axisConfirmed: false,
+      running: false,
+    };
     this.fileId = null;
     this.materialProfile = null;
     this.demouldAxis = null;
@@ -111,19 +117,20 @@ class DFMOrchestrator {
     this.axisValidated = false;
     this.axisSelection = null;
     this.selectedAxis = null;
+    this.selectedInvert = false;
     // panneau d'axe injecté à la volée
     this.axisPanel = null;
     this.axisPanelInitialized = false;
     this.axisPicker = null;
+    this.confirmedAxis = null;
   }
 
   init(){
-    // Binding en JS pour éviter l'attribut onclick inline
+    document.getElementById('dfmAxisPanel')?.remove();
     document.getElementById('analyzeBtn')?.addEventListener('click', () => this.handleAnalyzeClick());
 
-    // -- Écouteurs globaux (ajoutés une fois) --
     window.addEventListener('material:selected', (e) => {
-      this.materialProfile = e.detail.materialProfile;
+      this.setMaterialProfile(e.detail.materialProfile);
       window.CAD.materialProfile = this.materialProfile;
       dbg('material:selected', this.materialProfile);
       this.renderAxisPanel();
@@ -131,36 +138,51 @@ class DFMOrchestrator {
 
     window.addEventListener('axis:confirmed', (e) => {
       this.selectedAxis = e.detail.axis;
-      dbg('axis:confirmed', this.selectedAxis);
-      // Préconditions minimales avant d’appeler l’API DFM
-      if (!this.fileId || !this.materialProfile || !this.selectedAxis){
-        UI.info('Importez un STEP, choisissez une matière et un axe.');
-        dbg('startAnalysis bloqué', { fileId: this.fileId, materialProfile: !!this.materialProfile, axis: this.selectedAxis });
-        return;
-      }
-      this.startAnalysis({
-        fileId: this.fileId,
-        materialProfile: this.materialProfile,
-        axis: this.selectedAxis
-      });
+      this.selectedInvert = !!e.detail.invert;
+      this.state.axisConfirmed = true;
+      dbg('axis:confirmed', this.selectedAxis, this.selectedInvert);
+      this.startAnalysis();
     });
   }
 
   setState(next){
-    this.state = next; dbg("state →", next);
+    this.phase = next; dbg("state →", next);
   }
 
   setFileId(id){
-    this.fileId = id || null;
+    if (!id) return false;
+    if (this.fileId && this.fileId !== id) {
+      console.warn('[DFM] file_id mismatch', this.fileId, id);
+      return false;
+    }
+    this.fileId = id;
+    this.state.fileLoaded = true;
+    this.state.axisConfirmed = false;
     const hidden = document.getElementById('fileId');
     if (hidden && hidden.type === 'hidden') hidden.value = this.fileId || '';
     this.refreshAxisState?.();
+    return true;
   }
   setMaterialProfile(p){
     this.materialProfile = p || null;
+    this.state.materialSelected = !!this.materialProfile;
+    this.state.axisConfirmed = false;
     this.resetAxisValidation();
     dbg('material selected', this.materialProfile, 'axis reset');
     this.refreshAxisState?.();
+  }
+  async debugFileId(){
+    if (!this.fileId) {
+      console.warn('[DFM] debugFileId: aucun file_id');
+      return;
+    }
+    try {
+      const res = await fetch(`/api/dfm/debug/file/${this.fileId}`);
+      const data = await res.json().catch(()=>({}));
+      console.debug('[DFM debug]', data);
+    } catch (err) {
+      console.warn('debugFileId failed', err);
+    }
   }
   setDemouldAxis(a){
     const vec = axisToVector(a);
@@ -300,13 +322,9 @@ class DFMOrchestrator {
 
   // Affiche le sélecteur d'axe sous le viewer
   renderAxisPanel() {
-    // 1) Garde-fous
+    if (!this.state.materialSelected) return;
     if (!this.fileId && typeof this.setFileIdFromPage === 'function' && !this.setFileIdFromPage()) {
       UI?.info?.("Aucun fichier à analyser. Merci d’importer une pièce.");
-      return;
-    }
-    if (!this.materialProfile) {
-      UI?.info?.("Sélectionnez un matériau avant de choisir l’axe.");
       return;
     }
 
@@ -335,6 +353,10 @@ class DFMOrchestrator {
           </div>
         </div>
         <div id="axisWidget" class="mt-2"></div>
+        <div class="form-check form-switch mt-2">
+          <input class="form-check-input" type="checkbox" id="invertAxisToggle">
+          <label class="form-check-label" for="invertAxisToggle">Inverser le sens</label>
+        </div>
       </div>`;
 
     viewerEl.insertAdjacentElement('afterend', panel);
@@ -364,6 +386,8 @@ class DFMOrchestrator {
       };
     }
 
+    this.invertToggle = panel.querySelector('#invertAxisToggle');
+
     // 6) Bouton "Valider l’axe" → émettre axis:confirmed
     panel.querySelector('#axisConfirmBtn')?.addEventListener('click', () => {
       const axis = this.axisPicker?.getAxis?.();
@@ -371,8 +395,9 @@ class DFMOrchestrator {
         UI?.info?.("Choisissez une direction d’axe avant de valider.");
         return;
       }
-      dbg('axis:confirmed emit', axis);
-      window.dispatchEvent(new CustomEvent('axis:confirmed', { detail: { axis } }));
+      const invert = !!this.invertToggle?.checked;
+      dbg('axis:confirmed emit', axis, invert);
+      window.dispatchEvent(new CustomEvent('axis:confirmed', { detail: { axis, invert } }));
       panel.scrollIntoView({ behavior: 'smooth', block: 'center' });
     });
   }
@@ -388,11 +413,18 @@ class DFMOrchestrator {
       }
       return;
     }
-    if (!this.materialProfile){
+    if (!this.state.materialSelected){
       showMaterialModal();
       return;
     }
-    this.renderAxisPanel();
+    if (this.state.materialSelected && !this.state.axisConfirmed){
+      this.renderAxisPanel();
+      document.getElementById('dfmAxisPanel')?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+      return;
+    }
+    if (this.state.axisConfirmed){
+      this.startAnalysis();
+    }
   }
 
   startDFM(){
@@ -430,141 +462,69 @@ class DFMOrchestrator {
   }
 
   // ---------------------- Analyse ----------------------
-    async startAnalysis({
-      fileId = this.fileId,
-      materialProfile = this.materialProfile,
-      axis = this.demouldAxis
-    } = {}) {
-      // Vérification minimale des prérequis
-      if (!materialProfile) {
-        dbg('startAnalysis: matière manquante');
-        console.warn("Aucun profil matière sélectionné, ouverture de la modale.");
-        showMaterialModal();
-        return;
-      }
-      // ➊ Résolution robuste du fileId au tout début
-    if (!fileId) {
-      // a) champ caché
-      const hid = document.getElementById('fileId');
-      if (hid && hid.value) fileId = hid.value;
+  async startAnalysis() {
+    const payload = {
+      file_id: this.fileId,
+      material_profile_id: this.materialProfile?.id,
+      axis: this.selectedAxis || { x: 0, y: 0, z: 1 },
+      invert: !!this.selectedInvert
+    };
+    console.debug('[DFM] start payload', payload);
 
-      // b) data-fileid sur <body>
-      if (!fileId && document?.body?.dataset?.fileid) {
-        fileId = document.body.dataset.fileid;
-      }
-
-      // c) global exposé par l’uploader
-      if (!fileId && window?.CADLYTICS?.current?.fileId) {
-        fileId = window.CADLYTICS.current.fileId;
-      }
-
-      // d) viewer éventuel
-      if (!fileId && window?.viewerAdapter?.current?.fileId) {
-        fileId = window.viewerAdapter.current.fileId;
-      }
-
-      // e) fallback orchestrateur
-      if (!fileId) fileId = this.setFileIdFromPage();
-
-      // On mémorise si trouvé
-      if (fileId) this.setFileId(fileId);
+    if (!payload.file_id || !payload.material_profile_id || !payload.axis) {
+      UI.info?.('Paramètre manquant pour l’analyse.');
+      return;
     }
 
-    // ➋ Garde-fous côté UI
-      if (!fileId) {
-        UI.info("Aucun fichier à analyser. Merci d’importer une pièce.");
-        dbg('startAnalysis: fileId manquant');
-        this.handleError?.("file_missing");
-        return;
-      }
-      if (!materialProfile) {
-        UI.info("Sélectionnez une matière.");
-        dbg('startAnalysis: matière manquante après résolution');
-        this.handleError?.("material_missing");
-        return;
-      }
-      if (!axis) {
-        UI.info("Veuillez valider l’axe de démoulage.");
-        dbg('startAnalysis: axe manquant');
-        this.handleError?.("axe_manquant");
-        return;
-      }
-
-    dbg("startAnalysis", { fileId, materialProfile, axis });
-    this.setState(DFM_STATES.RUNNING);
-    this._renderLoading();
-    UI.setLoading(true);
-
-    const payload = {
-      file_id: fileId,
-      axis,
-      material_profile: materialProfile?.resin || "GENERIC",
-    };
-    dbg('start payload', payload);
-
-
+    UI.setLoading?.(true);
+    this.state.running = true;
     try {
-      const res = await fetch("/api/dfm/start", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
+      const res = await fetch('/api/dfm/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(payload)
       });
-
-      let startResp = {};
-      try { startResp = await res.json(); } catch {}
-
-      dbg('POST /api/dfm/start', res.status, startResp);
-
-      if (res.status === 200 || res.status === 202) {
-        const { job_id: jobId } = startResp;
-        if (jobId) {
-          window.CAD.currentJobId = jobId;
-          StatusUI.set("Analyse en cours…");
-          pollJobStatus(
-            jobId,
-            (s) => {
-              if (s.status === "running") {
-                const label = s.step ? `Analyse en cours… (${s.step})` : "Analyse en cours…";
-                StatusUI.set(label);
-                if (typeof s.progress === "number" && UI.progress) UI.progress(s.progress);
-              }
-            },
-            async () => {
-              StatusUI.set("Analyse terminée");
-              const r = await fetch(`/api/dfm/result?job_id=${encodeURIComponent(jobId)}`);
-              if (r.ok){
-                const data = await r.json();
-                await this.renderResults(data);
-              }else{
-                this.handleError("result_failed");
-              }
-            },
-            () => { StatusUI.set("Échec de l’analyse"); UI.err("Échec de l’analyse"); }
-          );
-        } else {
-          this.handleError("missing_jobId");
-        }
+      let data = {};
+      try { data = await res.json(); } catch (e) {}
+      if (res.status !== 202) {
+        console.warn('DFM start rejected', res.status, data);
+        this.setStatus?.('start_failed', data?.error || 'Bad Request');
+        UI.setLoading?.(false);
         return;
       }
-
-      // Messages dédiés selon code HTTP
-      switch (res.status) {
-        case 400: UI.err("Aucun fichier: importez/convertez une pièce puis recommencez."); break;
-        case 404: UI.err("Endpoint introuvable"); break;
-        case 409: UI.err("Analyse déjà en cours pour ce fichier."); break;
-        case 503: UI.err("Service indisponible (worker/broker). Réessayez."); break;
-        default:  UI.err(`Erreur ${res.status} ${res.statusText}`);
-      }
-      this.handleError("start_failed");
-
-    } catch (e) {
-      console.error(e);
-      UI.err("Démarrage analyse impossible");
-      this.handleError("start_failed");
-
-    } finally {
-      UI.setLoading(false);
+      this.jobId = data.job_id;
+      this.pollStatus(this.jobId);
+    } catch (err) {
+      console.error('DFM start network error', err);
+      this.setStatus?.('start_failed', 'Network error');
+      UI.setLoading?.(false);
     }
+  }
+
+  pollStatus(jobId) {
+    pollJobStatus(
+      jobId,
+      (s) => {
+        if (s.status === 'queued') {
+          StatusUI.set('En file d’attente…');
+        } else if (s.status === 'running') {
+          const label = s.step ? `Analyse en cours… (${s.step})` : 'Analyse en cours…';
+          StatusUI.set(label);
+          if (typeof s.progress === 'number') UI.progress(s.progress);
+        }
+      },
+      () => {
+        StatusUI.set('Analyse terminée');
+        UI.setLoading(false);
+        this.state.running = false;
+      },
+      () => {
+        StatusUI.set('Analyse échouée');
+        UI.err('Analyse échouée');
+        UI.setLoading(false);
+        this.state.running = false;
+      }
+    );
   }
   async renderResults(results = {}){
     StatusUI.set("Analyse terminée");
@@ -735,11 +695,13 @@ eventBus.subscribe('dfm:start', async (payload) => {
       () => {
         StatusUI.set('Analyse terminée');
         UI.setLoading(false);
+        orchestrator.state.running = false;
       },
       () => {
         StatusUI.set('Analyse échouée');
         UI.err('Analyse échouée');
         UI.setLoading(false);
+        orchestrator.state.running = false;
       }
     );
   } catch (err) {
@@ -848,6 +810,8 @@ function initDFMUI() {
       window.CAD.fileIdStep = e.detail.fileId;
       orchestrator.setFileId(e.detail.fileId);
     });
+
+    document.getElementById('debugFileId')?.addEventListener('click', () => orchestrator.debugFileId());
 
     orchestrator.init();
   });

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -243,9 +243,12 @@ function collectMaterialFromForm() {
   const form = document.getElementById("materialQuestionnaireForm");
   if (!form) return {};
   const fd = new FormData(form);
-  const profile = { resin: fd.get("resin") || "GENERIC" };
+  const profile = {
+    id: fd.get("resin") || "GENERIC",
+    draft_min_deg: parseFloat(fd.get("draft_min_deg")) || 1.0,
+  };
   fd.forEach((v, k) => {
-    if (k === "resin") return;
+    if (k === "resin" || k === "draft_min_deg") return;
     const key = k.replace("[]", "");
     if (profile[key]) {
       if (!Array.isArray(profile[key])) profile[key] = [profile[key]];

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -1,58 +1,25 @@
-import os, time, logging, redis
+"""Celery task for running DFM analysis."""
+
 from celery import shared_task
 
-# --- Connexion Redis pour cache local ---
-redis_url = (
-    os.environ.get("REDIS_URL")
-    or os.environ.get("CELERY_BROKER_URL")
-    or "redis://localhost:6379/0"
-)
+from app.dfm.dfm_analyzer import run_dfm
+from app.storage import Storage
+from app.material_profiles import get_profile
 
-if redis_url.startswith("rediss://"):
-    cache = redis.from_url(redis_url, decode_responses=True, ssl=True, ssl_cert_reqs=None)
-else:
-    cache = redis.from_url(redis_url, decode_responses=True)
 
-safe_url = redis_url.replace(redis_url.split('@')[0], 'rediss://***:***@') if '@' in redis_url else redis_url
-print(f"[dfm] Redis connecté sur {safe_url}")
-
-# --- Tâche Celery ---
 @shared_task(bind=True, name="tasks.dfm.dfm_run")
-def dfm_run(self, file_id, material_profile, demould_axis):
-    """
-    Exemple simplifié d’analyse DFM avec suivi de progression.
-    """
-    t0 = time.time()
-
-    # Étape 1 : préparation
-    self.update_state(state="PROGRESS", meta={"step": "prepare", "progress": 5})
-    # TODO: parsing STEP avec cadquery/trimesh
-
-    # Étape 2 : calcul épaisseurs
-    self.update_state(state="PROGRESS", meta={"step": "thickness", "progress": 35})
-    # TODO: analyse d’épaisseur + stockage éventuel dans cache
-    cache.set(f"dfm:{file_id}:thickness", "done")
-
-    # Étape 3 : contre-dépouilles
-    self.update_state(state="PROGRESS", meta={"step": "undercuts", "progress": 70})
-    # TODO: analyse contre-dépouilles
-    cache.set(f"dfm:{file_id}:undercuts", "done")
-
-    # Étape 4 : synthèse
-    self.update_state(state="PROGRESS", meta={"step": "summary", "progress": 90})
-    # TODO: compilation résultats finaux
-    cache.set(f"dfm:{file_id}:summary", "done")
-
-    dt = time.time() - t0
-    logging.info("DFM %s terminé en %.2fs", file_id, dt)
-
-    return {
-        "ok": True,
+def dfm_run(self, file_id, material_profile_id, axis, invert=False):
+    """Run the DFM analysis for a given STEP file."""
+    step_path = Storage.get_step_path(file_id)
+    profile = get_profile(material_profile_id)
+    if profile is None:
+        raise ValueError("unknown_material_profile")
+    dfm_input = {
         "file_id": file_id,
-        "summary": {
-            "score": 86,
-            "duration": dt,
-            "axis": demould_axis,
-            "material": material_profile,
-        },
+        "step_path": step_path,
+        "axis": axis,
+        "invert": invert,
+        "material_profile": profile.model_dump(),
     }
+    return run_dfm(dfm_input, progress_cb=None, fast_mode=False)
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -770,7 +770,8 @@
 
                 ensureViewer();
               });
-            </script>
+              </script>
+              <button id="debugFileId" class="btn btn-sm btn-secondary d-none">Debug file_id</button>
 
 <script type="module" src="{{ url_for('static', filename='js/criteria-modal.js') }}" defer></script>
 <script type="module" src="{{ url_for('static', filename='js/DFMOrchestrator.js') }}" defer></script>

--- a/web.py
+++ b/web.py
@@ -50,6 +50,7 @@ from redis.exceptions import ConnectionError as RedisConnectionError
 from storage.s3 import get_signed_url
 from observability.logging import setup_logging, get_logger
 from api.dfm import dfm_bp
+from app.storage.storage import Storage
 
 load_dotenv()
 
@@ -129,6 +130,26 @@ def __routes():
     return "<pre>" + "\n".join(sorted(map(str, app.url_map.iter_rules()))) + "</pre>"
 
 # ========= FIN PATCH =========
+
+
+@app.get("/api/debug/file/<file_id>")
+def debug_file(file_id):
+    step = None
+    xkt = None
+    try:
+        step = Storage.get_step_path(file_id)
+    except FileNotFoundError:
+        step = None
+    try:
+        xkt = Storage.get_xkt_path(file_id)
+    except FileNotFoundError:
+        xkt = None
+    return jsonify({
+        "file_id": file_id,
+        "step_path": step,
+        "xkt_path": xkt,
+        "exists_step": bool(step and os.path.isfile(step)),
+    })
 
 
 


### PR DESCRIPTION
## Summary
- capture axis confirmation data and trigger analysis
- post validated DFM payload to backend and poll status
- keep original file_id if conversion returns a different one and expose debug endpoint
- enqueue DFM jobs via Celery and expose status/result through AsyncResult
- require a STEP path for DFM and surface failures through the API
- add /api/debug/file endpoint and log step resolution in dfm start
- collect material profile as `{id,draft_min_deg}` and reject unknown `material_profile_id`
- document manual QA checklist in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c1408b2698833381740085d308cd24