### PR TITLE
Log upload identifiers and paths

### DIFF
--- a/app/storage/storage.py
+++ b/app/storage/storage.py
@@ -1,15 +1,21 @@
-import os, sqlite3
+import os
+import sqlite3
+import logging
 from contextlib import closing
 
-DB_PATH = os.environ.get("FILES_DB_PATH", os.path.join(os.path.dirname(__file__), "files.sqlite"))
-UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
-OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+DB_PATH = os.path.abspath(
+    os.environ.get("FILES_DB_PATH", os.path.join(os.path.dirname(__file__), "files.sqlite"))
+)
+UPLOAD_FOLDER = os.path.abspath(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"))
+OUTPUT_FOLDER = os.path.abspath(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"))
 
 
 class Storage:
     @staticmethod
     def _connect():
-        os.makedirs(os.path.dirname(DB_PATH), exist_ok=True)
+        db_dir = os.path.dirname(DB_PATH)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
         return sqlite3.connect(DB_PATH)
 
     @staticmethod
@@ -30,6 +36,12 @@ class Storage:
             p = os.path.join(UPLOAD_FOLDER, f"{file_id}{ext}")
             if os.path.isfile(p):
                 return p
+        logging.getLogger(__name__).warning(
+            "[Storage] step not found for file_id=%s (db_path=%s, upload_folder=%s)",
+            file_id,
+            DB_PATH,
+            UPLOAD_FOLDER,
+        )
         return None
 
     @staticmethod

--- a/tasks/conversion.py
+++ b/tasks/conversion.py
@@ -8,7 +8,6 @@ from datetime import datetime
 import cadquery as cq
 import trimesh
 from PIL import Image
-from flask import current_app
 
 from models import db, ModelJob, advance_model_job_status
 from celery_app import celery
@@ -21,6 +20,7 @@ from observability.metrics import (
     preview_size_bytes,
     final_size_bytes,
 )
+from app.storage.storage import Storage
 logger = get_logger(__name__)
 MAX_RETRIES = 3
 PREVIEW_MAX_FACES = 300_000
@@ -47,7 +47,10 @@ def generate_preview(self, job_id: str) -> None:
         return
     advance_model_job_status(job, "processing")
     db.session.commit()
-    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{job.id}.step")
+    step_path = Storage.get_step_path(job.id)
+    if not step_path:
+        logger.error("step file missing: file_id=%s", job.id)
+        return
     tmp_dir = tempfile.mkdtemp(prefix="preview_")
     try:
         shape = cq.importers.importStep(step_path)
@@ -96,7 +99,10 @@ def generate_final(self, job_id: str) -> None:
         return
     advance_model_job_status(job, "processing")
     db.session.commit()
-    step_path = os.path.join(current_app.config["UPLOAD_FOLDER"], f"{job.id}.step")
+    step_path = Storage.get_step_path(job.id)
+    if not step_path:
+        logger.error("step file missing: file_id=%s", job.id)
+        return
     tmp_dir = tempfile.mkdtemp(prefix="final_")
     try:
         shape = cq.importers.importStep(step_path)

--- a/web.py
+++ b/web.py
@@ -702,7 +702,9 @@ def api_upload():
             'dfm_json_url': existing.dfm_json_url,
         })
 
+    file_id = str(uuid.uuid4())
     job = ModelJob(
+        id=file_id,
         sha256=digest,
         original_filename=filename,
         size_bytes=size,
@@ -712,25 +714,47 @@ def api_upload():
     db.session.add(job)
     db.session.commit()
 
-    final_path = os.path.join(app.config['UPLOAD_FOLDER'], f"{job.id}.step")
-    os.rename(tmp_path, final_path)
+    orig_ext = os.path.splitext(filename)[1].lower()
+    ext = orig_ext if orig_ext in ('.stp', '.step') else '.step'
+    abs_step_path = os.path.abspath(
+        os.path.join(app.config['UPLOAD_FOLDER'], f"{file_id}{ext}")
+    )
+    logger.info(
+        "upload pre-rename: file_id=%s tmp_path=%s", file_id, tmp_path
+    )
+    os.rename(tmp_path, abs_step_path)
     if upload_id:
         os.remove(info_path)
 
-    abs_step_path = os.path.abspath(final_path)
+    logger.info(
+        "upload post-rename: file_id=%s abs_step_path=%s", file_id, abs_step_path
+    )
+    logger.info(
+        "upload save_step_record: file_id=%s path=%s", file_id, abs_step_path
+    )
     Storage.save_step_record(
-        file_id=job.id,
+        file_id=file_id,
         filename=filename,
         path=abs_step_path,
         size=os.path.getsize(abs_step_path),
     )
+    logger.info("upload save_step_record OK: file_id=%s", file_id)
 
     generate_preview.delay(job.id)
     generate_final.delay(job.id)
 
-    logger.info(json.dumps({'action': 'upload', 'result': 'queued', 'job_id': job.id}))
+    logger.info(
+        json.dumps({'action': 'upload', 'result': 'queued', 'file_id': file_id})
+    )
 
-    return jsonify({'modelId': job.id, 'status': job.status, 'sha256': job.sha256}), 201
+    response_payload = {
+        'file_id': file_id,
+        'modelId': job.id,
+        'status': job.status,
+        'sha256': job.sha256,
+    }
+    logger.info("upload response: file_id=%s payload=%s", file_id, response_payload)
+    return jsonify(response_payload), 201
 
 
 @app.route('/api/models/<job_id>')


### PR DESCRIPTION
## Summary
- trace l'identifiant généré et le chemin final lors du renommage
- log l'appel à Storage.save_step_record et la réponse HTTP
- consolide la résolution des STEP via DB ou fallback et log si introuvable

## Testing
- `pytest tests/test_storage.py -q`
- `pytest tests/test_dfm_api.py::test_upload_and_analysis -q` *(404: assert 404 == 200)*
- `pytest tests/test_tus_upload.py::test_resumable_upload_resume -q` *(ImportError: cannot import name 'db' from 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68c15c6fa5b48333b2862b15ae604d88