### PR TITLE
Log boot env and persist STEP uploads

### DIFF
--- a/app/api/dfm_routes.py
+++ b/app/api/dfm_routes.py
@@ -50,21 +50,23 @@ def start() -> tuple[dict, int]:
     if not get_profile(material_profile_id):
         return jsonify({"error": "unknown_material_profile"}), 400
     step_path = Storage.get_step_path(file_id)
+    current_app.logger.info(
+        "[DFM/START] file_id=%s resolved_step=%s exists=%s",
+        file_id,
+        step_path,
+        bool(step_path and os.path.isfile(step_path)),
+    )
     if not step_path:
-        current_app.logger.warning(
-            "DFM start: step_not_found_for_file_id file_id=%s", file_id
-        )
         return (
             {
                 "error": "step_not_found_for_file_id",
-                "hint": "Upload must save /tmp/uploads/<file_id>.step|.stp and call Storage.save_step_record",
+                "hint": "persist via ensure_step_persisted → /tmp/uploads/<file_id>.step|.stp",
             },
             400,
         )
     logger.info("/api/dfm/start file_id=%s step_path=%s", file_id, step_path)
     job = dfm_run.delay(
         file_id=file_id,
-        step_path=step_path,
         material_profile_id=material_profile_id,
         axis=axis,
         invert=invert,
@@ -128,14 +130,15 @@ def result() -> tuple[dict, int]:
 
 @debug_bp.get("/debug/file/<file_id>")
 def debug_file(file_id: str):
-    from app.storage.storage import Storage
+    from app.storage.storage import Storage, os
     step = Storage.get_step_path(file_id)
     xkt = Storage.get_xkt_path(file_id)
     return {
         "file_id": file_id,
         "step_path": step,
-        "xkt_path": xkt,
         "exists_step": bool(step and os.path.isfile(step)),
+        "xkt_path": xkt,
+        "exists_xkt": bool(xkt and os.path.isfile(xkt)),
     }
 
 

--- a/app/app.py
+++ b/app/app.py
@@ -13,9 +13,24 @@ from .tasks import heavy_compute
 from server.dfm_api_blueprint_stub import dfm_bp
 from app.storage.storage import Storage
 
+log = logging.getLogger("boot")
+os.makedirs(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"), exist_ok=True)
+os.makedirs(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"), exist_ok=True)
+os.environ.setdefault(
+    "FILES_DB_PATH",
+    os.path.join(os.path.dirname(__file__), "storage/files.sqlite"),
+)
+log.info(
+    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s cwd=%s",
+    os.environ.get("UPLOAD_FOLDER"),
+    os.environ.get("OUTPUT_FOLDER"),
+    os.environ.get("FILES_DB_PATH"),
+    os.getcwd(),
+)
+
 app = Flask(__name__)
-app.config["UPLOAD_FOLDER"] = os.getenv("UPLOAD_FOLDER", "/tmp/uploads")
-app.config["OUTPUT_FOLDER"] = os.getenv("OUTPUT_FOLDER", "/tmp/converted")
+app.config["UPLOAD_FOLDER"] = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
+app.config["OUTPUT_FOLDER"] = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
 app.config["MAX_CONTENT_LENGTH"] = int(os.getenv("MAX_UPLOAD_MB", "300")) * 1024 * 1024
 app.config["COMPRESS_MIMETYPES"] = [
     "text/html",
@@ -26,8 +41,6 @@ app.config["COMPRESS_MIMETYPES"] = [
     "model/gltf-binary",
 ]
 
-os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
-os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
 
 compress = Compress()
 compress.init_app(app)
@@ -90,12 +103,7 @@ def upload():
         shutil.copyfileobj(file.stream, dst, length=1024 * 1024)
 
     abs_step_path = os.path.abspath(step_path)
-    Storage.save_step_record(
-        file_id=job_id,
-        filename=original_filename,
-        path=abs_step_path,
-        size=os.path.getsize(abs_step_path),
-    )
+    abs_step_path = Storage.ensure_step_persisted(job_id, abs_step_path, original_filename)
 
     low_job = q.enqueue(
         generate_low_preview,

--- a/app/storage/storage.py
+++ b/app/storage/storage.py
@@ -1,20 +1,14 @@
-import os
-import sqlite3
-import logging
+"""Persistence utilitaire pour les fichiers STEP/XKT."""
+
+import os, sqlite3, logging, shutil
 from contextlib import closing
 
-from . import files as storage_files
 
 logger = logging.getLogger("app.storage.storage")
 
-_db_env = os.environ.get("FILES_DB_PATH")
-if _db_env:
-    DB_PATH = os.path.abspath(_db_env)
-else:
-    DB_PATH = str(storage_files.DB_PATH)
-
-UPLOAD_FOLDER = os.path.abspath(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"))
-OUTPUT_FOLDER = os.path.abspath(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"))
+DB_PATH = os.environ.get("FILES_DB_PATH") or os.path.join(os.path.dirname(__file__), "files.sqlite")
+UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
+OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
 
 
 class Storage:
@@ -26,23 +20,40 @@ class Storage:
         return sqlite3.connect(DB_PATH)
 
     @staticmethod
+    def save_step_record(file_id: str, filename: str, path: str, size: int) -> None:
+        with closing(Storage._connect()) as con:
+            cur = con.cursor()
+            cur.execute(
+                "CREATE TABLE IF NOT EXISTS files (file_id TEXT PRIMARY KEY, filename TEXT, path TEXT, size INTEGER)"
+            )
+            cur.execute(
+                "INSERT OR REPLACE INTO files (file_id, filename, path, size) VALUES (?, ?, ?, ?)",
+                (file_id, filename, path, size),
+            )
+            con.commit()
+
+    @staticmethod
     def get_step_path(file_id: str) -> str | None:
-        # 1) SQLite index (table files: file_id, filename, path, size)
+        # 1) DB lookup
         try:
             with closing(Storage._connect()) as con:
                 cur = con.cursor()
-                cur.execute("CREATE TABLE IF NOT EXISTS files (file_id TEXT PRIMARY KEY, filename TEXT, path TEXT, size INTEGER)")
+                cur.execute(
+                    "CREATE TABLE IF NOT EXISTS files (file_id TEXT PRIMARY KEY, filename TEXT, path TEXT, size INTEGER)"
+                )
                 cur.execute("SELECT path FROM files WHERE file_id = ?", (file_id,))
                 row = cur.fetchone()
                 if row and row[0] and os.path.isfile(row[0]):
                     return row[0]
-        except Exception:
-            pass
-        # 2) Fallbacks: chemins dérivés par convention
+        except Exception as e:  # pragma: no cover
+            logger.warning("[Storage] DB lookup failed: %r", e)
+
+        # 2) Fallback by convention
         for ext in (".step", ".stp"):
             p = os.path.join(UPLOAD_FOLDER, f"{file_id}{ext}")
             if os.path.isfile(p):
                 return p
+
         logger.warning(
             "[Storage] step not found for file_id=%s (db_path=%s, upload_folder=%s)",
             file_id,
@@ -57,12 +68,21 @@ class Storage:
         return p if os.path.isfile(p) else None
 
     @staticmethod
-    def save_step_record(file_id: str, filename: str, path: str, size: int) -> None:
-        with closing(Storage._connect()) as con:
-            cur = con.cursor()
-            cur.execute("CREATE TABLE IF NOT EXISTS files (file_id TEXT PRIMARY KEY, filename TEXT, path TEXT, size INTEGER)")
-            cur.execute(
-                "INSERT OR REPLACE INTO files (file_id, filename, path, size) VALUES (?, ?, ?, ?)",
-                (file_id, filename, path, size),
+    def ensure_step_persisted(file_id: str, tmp_step_path: str, original_filename: str) -> str:
+        """Copy the uploaded/converted temp STEP into the canonical uploads dir and index it in SQLite if missing."""
+
+        os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+        ext = os.path.splitext(original_filename)[1].lower()
+        if ext not in (".step", ".stp"):
+            ext = ".step"
+        canonical = os.path.join(UPLOAD_FOLDER, f"{file_id}{ext}")
+        if not os.path.isfile(canonical):
+            shutil.copy2(tmp_step_path, canonical)
+            Storage.save_step_record(
+                file_id, original_filename, canonical, os.path.getsize(canonical)
             )
-            con.commit()
+            logger.info("[Storage] persisted STEP → %s", canonical)
+        else:
+            logger.info("[Storage] STEP already persisted → %s", canonical)
+        return canonical
+

--- a/src/main.js
+++ b/src/main.js
@@ -373,13 +373,12 @@ function showLoading(state){
 }
 
 /** Expose un fileId dans tous les points d’accès attendus par l’app */
-function exposeFileId(fileId) {
-  if (!fileId) return;
-  const existing = window.CADLYTICS?.current?.fileId;
-  if (existing && existing !== fileId) {
-    console.warn('[ID] ignore new id', fileId, 'keep', existing);
-    fileId = existing;
-  }
+function exposeFileId(incomingId) {
+  if (!incomingId) return;
+  if (!this.fileId) this.fileId = incomingId;
+  else if (this.fileId !== incomingId) console.warn('[ID] ignore new id', incomingId, 'keep', this.fileId);
+
+  const fileId = this.fileId;
 
   // 1) champ caché
   const h = document.getElementById('fileId');

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -63,24 +63,25 @@ export class XeokitModelViewer extends EventTarget {
   }
 
   // === Mini-patch : expose l’ID côté front (DOM + global + event)
-  _exposeFileId(id) {
-    if (!id) return;
-    if (!this.fileId) this.fileId = id;
-    else if (this.fileId !== id) {
-      console.warn('[ID] ignore new id', id, 'keep', this.fileId);
-      id = this.fileId;
-    }
-    document.body.dataset.fileid = this.fileId;
+  _exposeFileId(incomingId) {
+    if (!incomingId) return;
+    if (!this.fileId) this.fileId = incomingId;
+    else if (this.fileId !== incomingId)
+      console.warn('[ID] ignore new id', incomingId, 'keep', this.fileId);
+
+    const fileId = this.fileId;
+
+    document.body.dataset.fileid = fileId;
     window.CADLYTICS = window.CADLYTICS || {};
-    window.CADLYTICS.current = { jobId: this.fileId, modelId: this.fileId };
+    window.CADLYTICS.current = { jobId: fileId, modelId: fileId };
     window.viewerAdapter = window.viewerAdapter || {};
-    window.viewerAdapter.current = { jobId: this.fileId, modelId: this.fileId };
+    window.viewerAdapter.current = { jobId: fileId, modelId: fileId };
     const hidden = document.getElementById('fileId');
-    if (hidden && hidden.type === 'hidden') hidden.value = this.fileId;
-    window.dispatchEvent(new CustomEvent('dfm:fileReady', { detail: { fileId: this.fileId } }));
+    if (hidden && hidden.type === 'hidden') hidden.value = fileId;
+    window.dispatchEvent(new CustomEvent('dfm:fileReady', { detail: { fileId } }));
     window.state = window.state || {};
     window.state.fileLoaded = true;
-    console.debug('[VIEWER] fileId exposé:', this.fileId);
+    console.debug('[VIEWER] fileId exposé:', fileId);
   }
 
   // --- chargement ---------------------------------------------------------

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -4,11 +4,15 @@ from celery import shared_task
 
 from app.dfm.dfm_analyzer import run_dfm
 from app.material_profiles import get_profile
+from app.storage.storage import Storage
 
 
 @shared_task(bind=True, name="tasks.dfm.dfm_run")
-def dfm_run(self, file_id, step_path, material_profile_id, axis, invert=False):
+def dfm_run(self, file_id, material_profile_id, axis, invert=False):
     """Run the DFM analysis for a given STEP file."""
+    step_path = Storage.get_step_path(file_id)
+    if not step_path:
+        raise FileNotFoundError(f"step_not_found_for_file_id {file_id}")
     profile = get_profile(material_profile_id)
     if profile is None:
         raise ValueError("unknown_material_profile")

--- a/web.py
+++ b/web.py
@@ -14,6 +14,8 @@ from flask import (
     redirect,
     url_for,
     flash,
+    current_app,
+    abort,
 )
 from flask_cors import CORS
 from flask_migrate import Migrate
@@ -56,20 +58,22 @@ from api.dfm import dfm_bp, debug_bp
 load_dotenv()
 
 log = logging.getLogger("boot")
-UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
-OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
-FILES_DB_PATH = os.environ.get(
+os.makedirs(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"), exist_ok=True)
+os.makedirs(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"), exist_ok=True)
+os.environ.setdefault(
     "FILES_DB_PATH",
     os.path.join(os.path.dirname(__file__), "app/storage/files.sqlite"),
 )
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
 log.info(
-    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s",
-    UPLOAD_FOLDER,
-    OUTPUT_FOLDER,
-    FILES_DB_PATH,
+    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s cwd=%s",
+    os.environ.get("UPLOAD_FOLDER"),
+    os.environ.get("OUTPUT_FOLDER"),
+    os.environ.get("FILES_DB_PATH"),
+    os.getcwd(),
 )
+UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
+OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+FILES_DB_PATH = os.environ.get("FILES_DB_PATH")
 
 # ========= FLASK APP (corrigé) =========
 # Une seule création d'app, avec static+templates configurés
@@ -502,10 +506,39 @@ def convert_step():
     in_name = base + ext_lower           # garde l’extension d’origine en minuscule
     in_path = os.path.join(temp_dir, in_name)
     f.save(in_path)
-
     dest_dir = app.config.get("OUTPUT_FOLDER", "/tmp/converted")
     os.makedirs(dest_dir, exist_ok=True)
-    out_name = f"{uuid.uuid4()}.xkt"
+    if ext_lower in ('.step', '.stp'):
+        file_id = uuid.uuid4().hex
+        assert file_id, "file_id must be defined before persisting STEP"
+        original_filename = orig
+        persisted = Storage.ensure_step_persisted(file_id, in_path, original_filename)
+        exists = bool(persisted and os.path.isfile(persisted))
+        current_app.logger.info(
+            "[UPLOAD→PERSIST] file_id=%s tmp=%s persisted=%s exists=%s",
+            file_id,
+            in_path,
+            persisted,
+            exists,
+        )
+        chk = Storage.get_step_path(file_id)
+        ok = bool(chk and os.path.isfile(chk))
+        current_app.logger.info(
+            "[VERIFY] get_step_path(file_id=%s) -> %s exists=%s",
+            file_id,
+            chk,
+            ok,
+        )
+        if not ok:
+            current_app.logger.error(
+                "[FATAL] STEP NOT FOUND JUST AFTER PERSIST. UPLOAD_FOLDER=%s FILES_DB_PATH=%s",
+                os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"),
+                os.environ.get("FILES_DB_PATH"),
+            )
+            abort(500, description="persist_step_failed")
+        out_name = f"{file_id}.xkt"
+    else:
+        out_name = f"{uuid.uuid4()}.xkt"
     out_path = os.path.join(dest_dir, out_name)
 
     start = time.time()
@@ -563,7 +596,10 @@ def convert_step():
     logger.info("Conversion OK en %.2fs -> %s", time.time() - start, out_path)
     # La route /uploads/<fname> doit servir OUTPUT_FOLDER
     xkt_rel_url = f"/uploads/{out_name}"
-    return jsonify(success=True, url=xkt_rel_url, xktUrl=xkt_rel_url)
+    resp = {"success": True, "url": xkt_rel_url, "xktUrl": xkt_rel_url}
+    if ext_lower in (".step", ".stp"):
+        resp["file_id"] = file_id
+    return jsonify(resp)
 
 
 @app.route('/upload_file', methods=['POST'])
@@ -579,13 +615,36 @@ def upload_file_api():
 
     file_id = str(uuid.uuid4())
     original_filename = secure_filename(file.filename)
-    ext = os.path.splitext(original_filename)[1].lower()
-    if ext not in ('.step', '.stp'):
-        ext = '.step'
-    abs_step_path = os.path.join(app.config['UPLOAD_FOLDER'], f"{file_id}{ext}")
-    file.save(abs_step_path)
-    step_size = os.path.getsize(abs_step_path)
-    Storage.save_step_record(file_id, original_filename, abs_step_path, step_size)
+    temp_dir = tempfile.mkdtemp(prefix="upload_")
+    tmp_step_path = os.path.join(temp_dir, original_filename)
+    file.save(tmp_step_path)
+    assert file_id, "file_id must be defined before persisting STEP"
+    persisted = Storage.ensure_step_persisted(file_id, tmp_step_path, original_filename)
+    exists = bool(persisted and os.path.isfile(persisted))
+    current_app.logger.info(
+        "[UPLOAD→PERSIST] file_id=%s tmp=%s persisted=%s exists=%s",
+        file_id,
+        tmp_step_path,
+        persisted,
+        exists,
+    )
+    chk = Storage.get_step_path(file_id)
+    ok = bool(chk and os.path.isfile(chk))
+    current_app.logger.info(
+        "[VERIFY] get_step_path(file_id=%s) -> %s exists=%s",
+        file_id,
+        chk,
+        ok,
+    )
+    if not ok:
+        current_app.logger.error(
+            "[FATAL] STEP NOT FOUND JUST AFTER PERSIST. UPLOAD_FOLDER=%s FILES_DB_PATH=%s",
+            os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"),
+            os.environ.get("FILES_DB_PATH"),
+        )
+        abort(500, description="persist_step_failed")
+    step_size = os.path.getsize(persisted)
+    shutil.rmtree(temp_dir, ignore_errors=True)
 
     stl_filename = f"{file_id}.stl"
     xkt_filename = f"{file_id}.xkt"
@@ -593,7 +652,7 @@ def upload_file_api():
     job = ConversionJob(
         id=file_id,
         original_filename=original_filename,
-        step_filename=os.path.basename(abs_step_path),
+        step_filename=os.path.basename(persisted),
         stl_filename=stl_filename,
         xkt_filename=xkt_filename,
         step_file_size=step_size,
@@ -638,6 +697,36 @@ def upload():
     input_path = os.path.join(temp_dir, filename)
     file.save(input_path)
 
+    # Persister le STEP avant toute conversion
+    file_id = uuid.uuid4().hex
+    if ext in (".step", ".stp"):
+        assert file_id, "file_id must be defined before persisting STEP"
+        original_filename = filename
+        persisted = Storage.ensure_step_persisted(file_id, input_path, original_filename)
+        exists = bool(persisted and os.path.isfile(persisted))
+        current_app.logger.info(
+            "[UPLOAD→PERSIST] file_id=%s tmp=%s persisted=%s exists=%s",
+            file_id,
+            input_path,
+            persisted,
+            exists,
+        )
+        chk = Storage.get_step_path(file_id)
+        ok = bool(chk and os.path.isfile(chk))
+        current_app.logger.info(
+            "[VERIFY] get_step_path(file_id=%s) -> %s exists=%s",
+            file_id,
+            chk,
+            ok,
+        )
+        if not ok:
+            current_app.logger.error(
+                "[FATAL] STEP NOT FOUND JUST AFTER PERSIST. UPLOAD_FOLDER=%s FILES_DB_PATH=%s",
+                os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"),
+                os.environ.get("FILES_DB_PATH"),
+            )
+            abort(500, description="persist_step_failed")
+
     if filename.endswith('.xkt'):
         out_name = f"{uuid.uuid4()}.xkt"
         dest_dir = os.path.join('static', 'models')
@@ -646,7 +735,7 @@ def upload():
         shutil.rmtree(temp_dir, ignore_errors=True)
         return redirect(url_for('index', model=out_name))
 
-    xkt_name = f"{uuid.uuid4()}.xkt"
+    xkt_name = f"{file_id}.xkt"
     xkt_path = os.path.join(temp_dir, xkt_name)
 
     try:
@@ -733,31 +822,12 @@ def api_upload():
     db.session.add(job)
     db.session.commit()
 
-    orig_ext = os.path.splitext(filename)[1].lower()
-    ext = orig_ext if orig_ext in ('.stp', '.step') else '.step'
-    abs_step_path = os.path.abspath(
-        os.path.join(app.config['UPLOAD_FOLDER'], f"{file_id}{ext}")
-    )
-    logger.info(
-        "upload pre-rename: file_id=%s tmp_path=%s", file_id, tmp_path
-    )
-    os.rename(tmp_path, abs_step_path)
+    abs_step_path = Storage.ensure_step_persisted(file_id, tmp_path, filename)
     if upload_id:
         os.remove(info_path)
-
-    logger.info(
-        "upload post-rename: file_id=%s abs_step_path=%s", file_id, abs_step_path
-    )
-    logger.info(
-        "upload save_step_record: file_id=%s path=%s", file_id, abs_step_path
-    )
-    Storage.save_step_record(
-        file_id=file_id,
-        filename=filename,
-        path=abs_step_path,
-        size=os.path.getsize(abs_step_path),
-    )
-    logger.info("upload save_step_record OK: file_id=%s", file_id)
+    if tmp_path != abs_step_path:
+        os.remove(tmp_path)
+    logger.info("upload persisted: file_id=%s step_path=%s", file_id, abs_step_path)
 
     generate_preview.delay(file_id)
     generate_final.delay(file_id)
@@ -830,8 +900,8 @@ def upload_job():
             ext = '.step'
         abs_step_path = os.path.abspath(os.path.join(app.config['UPLOAD_FOLDER'], f"{file_id}{ext}"))
         file.save(abs_step_path)
+        abs_step_path = Storage.ensure_step_persisted(file_id, abs_step_path, original_filename)
         step_size = os.path.getsize(abs_step_path)
-        Storage.save_step_record(file_id, original_filename, abs_step_path, step_size)
         logger.info(f"Saved STEP file: {abs_step_path}")
 
         step_filename = os.path.basename(abs_step_path)

--- a/worker.py
+++ b/worker.py
@@ -1,16 +1,25 @@
 # worker.py — Celery worker entrypoint for Render
 # Import the existing Celery app instance without going through web.py to avoid side effects.
 
-import logging
 import os
+import logging
 
 logging.basicConfig(level=logging.INFO)
-logging.info("worker.py starting Celery worker")
-
-UPLOAD_FOLDER = os.getenv("UPLOAD_FOLDER", "/tmp/uploads")
-OUTPUT_FOLDER = os.getenv("OUTPUT_FOLDER", "/tmp/converted")
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
+log = logging.getLogger("boot")
+os.makedirs(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"), exist_ok=True)
+os.makedirs(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"), exist_ok=True)
+os.environ.setdefault(
+    "FILES_DB_PATH",
+    os.path.join(os.path.dirname(__file__), "app/storage/files.sqlite"),
+)
+log.info(
+    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s cwd=%s",
+    os.environ.get("UPLOAD_FOLDER"),
+    os.environ.get("OUTPUT_FOLDER"),
+    os.environ.get("FILES_DB_PATH"),
+    os.getcwd(),
+)
+log.info("worker.py starting Celery worker")
 
 from celery_app import celery  # the project must already expose `celery` in celery_app.py
 


### PR DESCRIPTION
## Summary
- Log resolved STEP path before queuing DFM job and return 400 when missing
- Keep initial file ID on the client viewer and ignore subsequent IDs
- Log storage locations when the Celery worker starts

## Testing
- `npm run build`
- `pytest tests/test_storage.py tests/test_debug_file.py -q`
- `pytest -q` *(fails: ImportError: cannot import name 'db' from 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68c172a8527c8333a9d648d521d66847