### PR TITLE
Log boot info, check XKT availability, and return JSON errors

### DIFF
--- a/app/api/contract_routes.py
+++ b/app/api/contract_routes.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 import time
 import uuid
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,7 @@ from flask import Blueprint, current_app, jsonify, request
 from werkzeug.utils import secure_filename
 
 from app.storage.storage import Storage
+from app.storage import history as History
 
 UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
 OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
@@ -41,6 +43,11 @@ def upload_step() -> tuple[Any, int]:
     step_path = os.path.join(UPLOAD_FOLDER, f"{file_id}.step")
     file.save(step_path)
     Storage.save_step_record(file_id, filename, step_path, size)
+    current_app.logger.info("[upload] file_id=%s name=%s size=%s", file_id, filename, size)
+    try:
+        History.record_upload(file_id, filename, size, datetime.utcnow().isoformat())
+    except Exception as exc:  # fail soft
+        current_app.logger.warning("history upload failed for %s: %s", file_id, exc)
 
     try:  # pragma: no cover - heavy libs
         import cadquery as cq
@@ -65,23 +72,24 @@ def convert_step() -> tuple[Any, int]:
     file_id = data.get("file_id")
     if not file_id:
         current_app.logger.warning("/convert missing file_id")
-        return jsonify({"error": "missing_or_unknown_file_id"}), 400
+        return jsonify({"error": "missing_or_unknown_file_id", "message": "file_id manquant"}), 400
 
     step_path = Storage.get_step_path(file_id)
     if not step_path or not os.path.isfile(step_path):
         current_app.logger.warning("/convert unknown file_id=%s", file_id)
-        return jsonify({"error": "missing_or_unknown_file_id"}), 400
+        return jsonify({"error": "missing_or_unknown_file_id", "message": "file_id inconnu"}), 400
 
     tolerance_raw = data.get("tolerance", 0.1)
     try:
         tolerance = float(tolerance_raw)
     except (TypeError, ValueError):
         current_app.logger.warning("/convert invalid tolerance=%r", tolerance_raw)
-        return jsonify({"error": "invalid_tolerance"}), 422
+        return jsonify({"error": "invalid_tolerance", "message": "tolerance invalide"}), 422
 
     os.makedirs(OUTPUT_FOLDER, exist_ok=True)
     xkt_path = os.path.join(OUTPUT_FOLDER, f"{file_id}.xkt")
     preview_path = os.path.join(OUTPUT_FOLDER, f"{file_id}.png")
+    current_app.logger.info("[convert] file_id=%s", file_id)
 
     cmd = ["python", "xkt_converter.py", step_path, xkt_path]
     current_app.logger.info(
@@ -96,23 +104,28 @@ def convert_step() -> tuple[Any, int]:
         duration = time.time() - t0
         current_app.logger.error("conversion timeout for %s after %.1fs", file_id, duration)
         return (
-            jsonify({"error": "xkt_convert_failed", "details": "timeout"}),
+            jsonify({"error": "xkt_convert_failed", "message": "timeout"}),
+            502,
+        )
+    except FileNotFoundError as exc:
+        current_app.logger.error("converter missing for %s: %s", file_id, exc)
+        return (
+            jsonify({"error": "xkt_convert_failed", "message": str(exc)[:200]}),
             502,
         )
 
     duration = time.time() - t0
     if res.returncode != 0:
-        stderr = (res.stderr or "").strip()[:200]
+        stderr = ((res.stdout or "") + (res.stderr or "")).strip()[:200]
         current_app.logger.error(
             "conversion failed rc=%s for %s: %s", res.returncode, file_id, stderr
         )
         return (
-            jsonify({"error": "xkt_convert_failed", "details": stderr}),
+            jsonify({"error": "xkt_convert_failed", "message": stderr}),
             502,
         )
 
     current_app.logger.info("conversion ok for %s in %.1fs", file_id, duration)
-
     try:
         from generate_thumbnails import generate_thumbnails
         thumbs = generate_thumbnails(step_path, OUTPUT_FOLDER)
@@ -120,6 +133,11 @@ def convert_step() -> tuple[Any, int]:
     except Exception as exc:  # pragma: no cover
         current_app.logger.warning("thumbnail generation failed for %s: %s", file_id, exc)
         Path(preview_path).write_bytes(b"")
+
+    try:
+        History.record_convert(file_id, duration * 1000)
+    except Exception as exc:  # fail soft
+        current_app.logger.warning("history convert failed for %s: %s", file_id, exc)
 
     return (
         jsonify({
@@ -140,10 +158,25 @@ def analyze_step() -> tuple[Any, int]:
     if not file_id or not axis or not material:
         return jsonify({"error": "file_id_axis_material_required"}), 400
     report_id = str(uuid.uuid4())
+    current_app.logger.info("[dfm] file_id=%s", file_id)
     result = {
         "report_id": report_id,
         "dfm_score": 0,
         "issues": [],
         "step_used": True,
     }
+    try:
+        History.record_analyze(file_id, report_id, result["dfm_score"])
+    except Exception as exc:  # fail soft
+        current_app.logger.warning("history analyze failed for %s: %s", file_id, exc)
     return jsonify(result), 200
+
+
+@api_contract_bp.get("/history")
+def get_history() -> tuple[Any, int]:
+    try:
+        entries = History.list_history()
+    except Exception as exc:  # fail soft
+        current_app.logger.warning("history list failed: %s", exc)
+        entries = []
+    return jsonify(entries), 200

--- a/app/storage/history.py
+++ b/app/storage/history.py
@@ -1,0 +1,103 @@
+"""Simple JSON history store for upload/convert/analyze events."""
+import json
+import os
+import threading
+from datetime import datetime
+from typing import Any, Dict, List
+import logging
+
+logger = logging.getLogger(__name__)
+_lock = threading.Lock()
+
+
+def _path() -> str:
+    base = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+    return os.environ.get("HISTORY_FILE", os.path.join(base, "history.json"))
+
+
+def _load() -> List[Dict[str, Any]]:
+    try:
+        with open(_path(), "r", encoding="utf-8") as f:
+            return json.load(f)
+    except Exception:
+        return []
+
+
+def _save(entries: List[Dict[str, Any]]) -> None:
+    try:
+        p = _path()
+        os.makedirs(os.path.dirname(p), exist_ok=True)
+        tmp = p + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(entries, f)
+        os.replace(tmp, p)
+    except Exception as e:  # pragma: no cover - fail soft
+        logger.warning("history save failed: %s", e)
+
+
+def record_upload(file_id: str, filename: str, size: int, created_at: str | None = None) -> None:
+    created_at = created_at or datetime.utcnow().isoformat()
+    with _lock:
+        entries = [e for e in _load() if e.get("file_id") != file_id]
+        entries.append(
+            {
+                "file_id": file_id,
+                "filename": filename,
+                "size": size,
+                "created_at": created_at,
+            }
+        )
+        _save(entries)
+
+
+def record_convert(file_id: str, convert_ms: float) -> None:
+    with _lock:
+        entries = _load()
+        found = False
+        for e in entries:
+            if e.get("file_id") == file_id:
+                e["xkt_ready"] = True
+                e["convert_ms"] = int(convert_ms)
+                found = True
+                break
+        if not found:
+            entries.append(
+                {
+                    "file_id": file_id,
+                    "created_at": datetime.utcnow().isoformat(),
+                    "xkt_ready": True,
+                    "convert_ms": int(convert_ms),
+                }
+            )
+        _save(entries)
+
+
+def record_analyze(file_id: str, report_id: str, dfm_score: float) -> None:
+    with _lock:
+        entries = _load()
+        found = False
+        for e in entries:
+            if e.get("file_id") == file_id:
+                e["report_id"] = report_id
+                e["dfm_score"] = dfm_score
+                found = True
+                break
+        if not found:
+            entries.append(
+                {
+                    "file_id": file_id,
+                    "created_at": datetime.utcnow().isoformat(),
+                    "report_id": report_id,
+                    "dfm_score": dfm_score,
+                }
+            )
+        _save(entries)
+
+
+def list_history() -> List[Dict[str, Any]]:
+    entries = _load()
+    try:
+        entries.sort(key=lambda e: e.get("created_at", ""), reverse=True)
+    except Exception:
+        pass
+    return entries

--- a/boot.py
+++ b/boot.py
@@ -1,0 +1,63 @@
+# Boot-time checks for directories and converter availability.
+
+import logging
+import os
+import shutil
+import subprocess
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("boot")
+
+UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
+OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+
+for d in (UPLOAD_FOLDER, OUTPUT_FOLDER):
+    os.makedirs(d, exist_ok=True)
+
+
+def _xeokit_cmd() -> list[str]:
+    exe = (os.environ.get("XEOKIT_CONVERT") or "").strip()
+    if exe:
+        if exe == "npx":
+            return ["npx", "-y", "@xeokit/xeokit-convert", "--version"]
+        if os.path.isfile(exe) and os.access(exe, os.X_OK):
+            return [exe, "--version"]
+    p = shutil.which("xeokit-convert")
+    if p:
+        return [p, "--version"]
+    return ["npx", "-y", "@xeokit/xeokit-convert", "--version"]
+
+
+def _check_xkt(timeout: int = 5) -> bool:
+    cmd = _xeokit_cmd()
+    try:
+        subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=timeout,
+            check=True,
+            text=True,
+        )
+        logger.info("XKT converter OK")
+        return True
+    except Exception as exc:
+        logger.warning("XKT converter unavailable: %s", exc)
+        return False
+
+
+XKT_AVAILABLE = _check_xkt()
+
+parts = [
+    f"UPLOAD_FOLDER={UPLOAD_FOLDER}",
+    f"OUTPUT_FOLDER={OUTPUT_FOLDER}",
+]
+max_upload = os.environ.get("MAX_UPLOAD_MB")
+if max_upload:
+    parts.append(f"MAX_UPLOAD_MB={max_upload}")
+path_env = os.environ.get("PATH", "")[:200]
+parts.append(f"PATH={path_env}")
+parts.append(f"XKT={int(XKT_AVAILABLE)}")
+
+logger.info("BOOT_OK " + " ".join(parts))
+

--- a/errors.py
+++ b/errors.py
@@ -1,0 +1,43 @@
+"""Gestion centralisée des réponses d'erreur JSON."""
+from __future__ import annotations
+
+import uuid
+from http import HTTPStatus
+from typing import Dict
+
+from flask import jsonify, current_app
+from werkzeug.exceptions import HTTPException
+
+# Mapping des codes vers un identifiant d'erreur stable
+ERROR_NAMES: Dict[int, str] = {
+    400: "bad_request",
+    401: "unauthorized",
+    403: "forbidden",
+    404: "not_found",
+    413: "payload_too_large",
+    415: "unsupported_media_type",
+    422: "unprocessable_entity",
+    429: "too_many_requests",
+    502: "bad_gateway",
+    504: "gateway_timeout",
+}
+
+
+def register_error_handlers(app) -> None:
+    """Enregistre des handlers Flask renvoyant systématiquement du JSON."""
+
+    @app.errorhandler(Exception)
+    def handle_exception(exc: Exception):
+        if isinstance(exc, HTTPException):
+            code = exc.code or 500
+            if code == 500:
+                trace_id = str(uuid.uuid4())
+                current_app.logger.exception("Unhandled 500 %s", trace_id, exc_info=exc)
+                return jsonify({"error": "internal_error", "trace_id": trace_id}), 500
+            name = ERROR_NAMES.get(code, HTTPStatus(code).name.lower())
+            message = exc.description or HTTPStatus(code).phrase
+            return jsonify({"error": name, "message": message}), code
+
+        trace_id = str(uuid.uuid4())
+        current_app.logger.exception("Unhandled exception %s", trace_id, exc_info=exc)
+        return jsonify({"error": "internal_error", "trace_id": trace_id}), 500

--- a/src/main.js
+++ b/src/main.js
@@ -347,6 +347,44 @@ function byId(name) {
   return document.getElementById(name);
 }
 
+// ----------- Historique ----------------------------------------------------
+function renderHistory(entries) {
+  const tbody = document.getElementById('historyTableBody');
+  const loading = document.getElementById('historyLoading');
+  if (loading) loading.classList.add('d-none');
+  if (!tbody) return;
+  tbody.innerHTML = '';
+  if (!entries || !entries.length) {
+    tbody.innerHTML = '<tr><td colspan="5" class="text-center text-muted py-4">Aucun historique de conversion disponible</td></tr>';
+    return;
+  }
+  entries.forEach((e) => {
+    const status = e.dfm_score !== undefined ? 'analyzed' : (e.xkt_ready ? 'converted' : 'uploaded');
+    const score = e.dfm_score !== undefined ? e.dfm_score : '';
+    const date = e.created_at ? new Date(e.created_at).toLocaleString() : '';
+    const actions = e.report_id ? `<a href="/reports/${e.report_id}.html" class="btn btn-sm btn-outline-primary">Voir</a>` : '';
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${e.filename || e.file_id}</td><td>${date}</td><td>${status}</td><td>${score}</td><td>${actions}</td>`;
+    tbody.appendChild(tr);
+  });
+}
+
+async function refreshHistory() {
+  try {
+    const res = await fetch('/api/simple/history');
+    const data = await res.json().catch(() => []);
+    renderHistory(data);
+  } catch (err) {
+    console.warn('history load failed', err);
+    renderHistory([]);
+  }
+}
+
+if (typeof window !== 'undefined') {
+  window.refreshHistory = refreshHistory;
+  document.addEventListener('DOMContentLoaded', () => refreshHistory());
+}
+
 (function wireUploadAndPreview(){
   const uploadArea = document.getElementById('uploadArea') || document.querySelector('.upload-area');
   if (!uploadArea || uploadArea.dataset.previewBound === '1') return;
@@ -420,6 +458,7 @@ async function uploadStepFile(file){
     }
     exposeFileId.call(state, data.file_id);
     lastXktUrl = null;
+    window.refreshHistory?.();
   }catch(e){
     console.error('[upload] error', e);
     window.showToast ? showToast('Upload échoué',{type:'error'}) : alert('Upload échoué');
@@ -435,7 +474,8 @@ async function uploadStepFile(file){
 async function convertCurrent(){
   const fileId = state.fileId;
   if (!fileId){
-    window.showToast ? showToast('Aucun fichier',{type:'error'}) : alert('Aucun fichier');
+    const msg = 'Importe un STEP d\u2019abord.';
+    window.showToast ? showToast(msg,{type:'error'}) : alert(msg);
     return;
   }
   try{
@@ -454,6 +494,7 @@ async function convertCurrent(){
     }
     console.info('[convert] xkt=', data.xkt_path);
     await loadXKTFromConvertResponse.call(state, { file_id: fileId, xkt_url: data.xkt_path });
+    window.refreshHistory?.();
   }catch(e){
     console.error('[convert] error', e);
     window.showToast ? showToast('Conversion échouée',{type:'error'}) : alert('Conversion échouée');

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -404,7 +404,7 @@ class DFMOrchestrator {
 
   handleAnalyzeClick(){
     if (!this.fileId){
-      UI.info("Importe un STEP");
+      UI.info("Importe un STEP d\u2019abord.");
       const zone = document.getElementById('uploadArea') || document.getElementById('dropzone');
       if (zone){
         zone.scrollIntoView({ behavior: 'smooth', block: 'center' });
@@ -492,6 +492,7 @@ class DFMOrchestrator {
       }
       console.info('[dfm] report=', data.report_id);
       await this.renderResults(data);
+      window.refreshHistory?.();
     } catch (err) {
       console.error('DFM start network error', err);
       this.handleError?.('Network error');

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import subprocess
+import os
 
 import pytest
 from flask import Flask
@@ -20,12 +21,21 @@ SAMPLE_STEP = Path("tests/sample.step")
 
 
 def test_upload_convert_analyze_flow(client, monkeypatch):
+    history_path = Path(os.environ.get("OUTPUT_FOLDER", "/tmp/converted")) / "history.json"
+    if history_path.exists():
+        history_path.unlink()
+
     with SAMPLE_STEP.open("rb") as fh:
         resp = client.post("/api/simple/upload", data={"file": fh})
     assert resp.status_code == 200
     data = resp.get_json()
     file_id = data["file_id"]
     assert Path(data["step_path"]).exists()
+
+    hist = client.get("/api/simple/history").get_json()
+    entry = next(e for e in hist if e["file_id"] == file_id)
+    assert entry["filename"].endswith(SAMPLE_STEP.name)
+    assert "xkt_ready" not in entry
 
     def fake_run(cmd, capture_output, text, timeout):
         Path(cmd[3]).write_bytes(b"x")
@@ -41,6 +51,11 @@ def test_upload_convert_analyze_flow(client, monkeypatch):
     assert Path(conv["xkt_path"]).exists()
     assert Path(conv["preview_png"]).exists()
 
+    hist = client.get("/api/simple/history").get_json()
+    entry = next(e for e in hist if e["file_id"] == file_id)
+    assert entry.get("xkt_ready") is True
+    assert entry.get("convert_ms") >= 0
+
     resp = client.post(
         "/api/simple/analyze",
         json={"file_id": file_id, "axis": [0, 0, 1], "material": "ABS", "options": {}},
@@ -50,17 +65,26 @@ def test_upload_convert_analyze_flow(client, monkeypatch):
     assert rep["report_id"]
     assert rep["dfm_score"] == 0
 
+    hist = client.get("/api/simple/history").get_json()
+    entry = next(e for e in hist if e["file_id"] == file_id)
+    assert entry.get("dfm_score") == 0
+    assert entry.get("report_id") == rep["report_id"]
+
 
 def test_convert_missing_file_id(client):
     resp = client.post("/api/simple/convert", json={})
     assert resp.status_code == 400
-    assert resp.get_json()["error"] == "missing_or_unknown_file_id"
+    data = resp.get_json()
+    assert data["error"] == "missing_or_unknown_file_id"
+    assert "message" in data
 
 
 def test_convert_unknown_file_id(client):
     resp = client.post("/api/simple/convert", json={"file_id": "nope"})
     assert resp.status_code == 400
-    assert resp.get_json()["error"] == "missing_or_unknown_file_id"
+    data = resp.get_json()
+    assert data["error"] == "missing_or_unknown_file_id"
+    assert "message" in data
 
 
 def test_convert_invalid_tolerance(client):
@@ -71,7 +95,9 @@ def test_convert_invalid_tolerance(client):
         "/api/simple/convert", json={"file_id": file_id, "tolerance": "Standard (0.1mm)"}
     )
     assert resp.status_code == 422
-    assert resp.get_json()["error"] == "invalid_tolerance"
+    data = resp.get_json()
+    assert data["error"] == "invalid_tolerance"
+    assert "message" in data
 
 
 def test_convert_failure_returns_502(client, monkeypatch):
@@ -90,4 +116,4 @@ def test_convert_failure_returns_502(client, monkeypatch):
     assert resp.status_code == 502
     body = resp.get_json()
     assert body["error"] == "xkt_convert_failed"
-    assert "boom" in body["details"]
+    assert "boom" in body["message"]

--- a/tests/test_boot.py
+++ b/tests/test_boot.py
@@ -1,0 +1,25 @@
+import importlib
+import logging
+import shutil
+import sys
+
+
+def test_boot_creates_dirs_and_logs(monkeypatch, tmp_path, caplog):
+    uploads = tmp_path / "up"
+    converted = tmp_path / "conv"
+    monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
+    monkeypatch.setenv("OUTPUT_FOLDER", str(converted))
+    monkeypatch.setenv("XEOKIT_CONVERT", shutil.which("echo"))
+    monkeypatch.setenv("PATH", "x")
+
+    if "boot" in sys.modules:
+        del sys.modules["boot"]
+
+    with caplog.at_level(logging.INFO):
+        boot = importlib.import_module("boot")
+        importlib.reload(boot)
+
+    assert uploads.exists()
+    assert converted.exists()
+    assert any("BOOT_OK" in rec.message for rec in caplog.records)
+

--- a/tests/test_error_handlers.py
+++ b/tests/test_error_handlers.py
@@ -1,0 +1,35 @@
+import uuid
+from flask import Flask
+
+from errors import register_error_handlers
+
+
+def create_app():
+    app = Flask(__name__)
+    register_error_handlers(app)
+
+    @app.get('/boom')
+    def boom():
+        raise RuntimeError('boom')
+
+    return app
+
+
+def test_404_returns_json():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/nope')
+    assert resp.status_code == 404
+    data = resp.get_json()
+    assert data['error'] == 'not_found'
+    assert isinstance(data['message'], str)
+
+
+def test_500_returns_trace_id():
+    app = create_app()
+    client = app.test_client()
+    resp = client.get('/boom')
+    assert resp.status_code == 500
+    data = resp.get_json()
+    uuid.UUID(data['trace_id'])
+    assert data['error'] == 'internal_error'

--- a/web.py
+++ b/web.py
@@ -20,7 +20,6 @@ from flask import (
 from flask_cors import CORS
 from flask_migrate import Migrate
 from werkzeug.utils import secure_filename, safe_join
-from werkzeug.exceptions import RequestEntityTooLarge
 import cadquery as cq
 import trimesh
 import uuid
@@ -52,32 +51,20 @@ from dotenv import load_dotenv
 from kombu.exceptions import OperationalError as KombuOperationalError
 from redis.exceptions import ConnectionError as RedisConnectionError
 from storage.s3 import get_signed_url
-from observability.logging import setup_logging, get_logger
 from api.dfm import dfm_bp, debug_bp
 from api.contract import api_contract_bp
+from errors import register_error_handlers
 
 load_dotenv()
 
-# >>> CADLYTICS PATCH: BOOT LOG (BEGIN)
-import os, logging
-log = logging.getLogger("boot")
-os.makedirs(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"), exist_ok=True)
-os.makedirs(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"), exist_ok=True)
-log.info(
-    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s cwd=%s",
-    os.environ.get("UPLOAD_FOLDER"),
-    os.environ.get("OUTPUT_FOLDER"),
-    os.environ.get("FILES_DB_PATH"),
-    os.getcwd(),
-)
-# >>> CADLYTICS PATCH: BOOT LOG (END)
+import boot
 
 os.environ.setdefault(
     "FILES_DB_PATH",
     os.path.join(os.path.dirname(__file__), "app/storage/files.sqlite"),
 )
-UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
-OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+UPLOAD_FOLDER = boot.UPLOAD_FOLDER
+OUTPUT_FOLDER = boot.OUTPUT_FOLDER
 FILES_DB_PATH = os.environ.get("FILES_DB_PATH")
 
 # ========= FLASK APP (corrigé) =========
@@ -89,6 +76,9 @@ app = Flask(
     template_folder="templates",
 )
 app.config["JSON_SORT_KEYS"] = False
+
+# Gestion des erreurs JSON
+register_error_handlers(app)
 
 # Enregistre les blueprints de l’API
 app.register_blueprint(dfm_bp)
@@ -103,7 +93,6 @@ init_celery(app)
 # Si indisponible / erreur de signature, on bascule sur le logging standard.
 
 try:
-    from observability.logging import setup_logging, get_logger
     # setup_logging attend l'app en paramètre dans ta lib
     setup_logging(app)                          # <-- IMPORTANT : on passe app
     logger = get_logger(__name__)               # ou get_logger("web")
@@ -168,10 +157,6 @@ def _resolve_xeokit():
         return xeokit
     logger.warning("xeokit-convert not found, falling back to npx")
     return "npx"
-
-@app.errorhandler(RequestEntityTooLarge)
-def handle_file_too_large(e):
-    return jsonify({"success": False, "error": "file_too_large"}), 413
 
 # Execute Celery tasks synchronously when no worker is running
 app.config['CELERY_TASK_ALWAYS_EAGER'] = os.getenv('CELERY_TASK_ALWAYS_EAGER', 'False').lower() == 'true'
@@ -368,13 +353,6 @@ FILE_RETENTION_DAYS = int(os.getenv('FILE_RETENTION_DAYS', '7'))
 app.config['UPLOAD_FOLDER'] = UPLOAD_FOLDER
 app.config['OUTPUT_FOLDER'] = OUTPUT_FOLDER
 app.config['FILE_RETENTION_DAYS'] = FILE_RETENTION_DAYS
-
-# Ensure directories exist
-os.makedirs(UPLOAD_FOLDER, exist_ok=True)
-os.makedirs(OUTPUT_FOLDER, exist_ok=True)
-logger.info("OUTPUT_FOLDER=%s", OUTPUT_FOLDER)
-
-logger.info("PATH at runtime=%s", os.getenv("PATH"))
 
 # Initialize Flask-Login
 login_manager = LoginManager(app)

--- a/worker.py
+++ b/worker.py
@@ -2,24 +2,17 @@
 # Import the existing Celery app instance without going through web.py to avoid side effects.
 
 
-# >>> CADLYTICS PATCH: BOOT LOG (BEGIN)
-import os, logging
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger("boot")
-os.makedirs(os.environ.get("UPLOAD_FOLDER", "/tmp/uploads"), exist_ok=True)
-os.makedirs(os.environ.get("OUTPUT_FOLDER", "/tmp/converted"), exist_ok=True)
+# Boot checks
+import logging
+import os
+import boot
+
 os.environ.setdefault(
     "FILES_DB_PATH",
     os.path.join(os.path.dirname(__file__), "app/storage/files.sqlite"),
 )
-log.info(
-    "[BOOT] UPLOAD_FOLDER=%s OUTPUT_FOLDER=%s FILES_DB_PATH=%s cwd=%s",
-    os.environ.get("UPLOAD_FOLDER"),
-    os.environ.get("OUTPUT_FOLDER"),
-    os.environ.get("FILES_DB_PATH"),
-    os.getcwd(),
-)
-# >>> CADLYTICS PATCH: BOOT LOG (END)
+
+log = logging.getLogger(__name__)
 log.info("worker.py starting Celery worker")
 
 from celery_app import celery  # the project must already expose `celery` in celery_app.py


### PR DESCRIPTION
## Summary
- Ensure upload, convert, and analyze steps log identifiable tags
- Prevent conversion/analysis when no STEP file and instruct users to upload first
- Guarantee upload/convert/analyze endpoints remain JSON-only with structured error codes
- Persist STEP processing history and expose it through `/api/simple/history`
- Display history on the frontend and refresh it after each pipeline step

## Testing
- `npm run build`
- `pytest tests/test_boot.py tests/test_api_contract.py tests/test_error_handlers.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29086a3f88333b74cf1634203098d