### PR TITLE
Expose legacy DFM endpoints and write report

### DIFF
--- a/api/dfm.py
+++ b/api/dfm.py
@@ -1,3 +1,3 @@
-from app.api.dfm_routes import dfm_bp, debug_bp
+from app.api.dfm_routes import dfm_bp, debug_bp, dfm_public_bp
 
-__all__ = ["dfm_bp", "debug_bp"]
+__all__ = ["dfm_bp", "debug_bp", "dfm_public_bp"]

--- a/app/api/dfm_routes.py
+++ b/app/api/dfm_routes.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from flask import Blueprint, jsonify, request
+import os
+import json
 from celery.result import AsyncResult
 from tasks.dfm import dfm_run
 from app.material_profiles import get_profile
@@ -14,6 +16,9 @@ logger = logging.getLogger(__name__)
 dfm_bp = Blueprint("dfm", __name__, url_prefix="/api/dfm")
 
 debug_bp = Blueprint("debug", __name__, url_prefix="/api")
+
+# Public endpoints without /api prefix
+dfm_public_bp = Blueprint("dfm_public", __name__, url_prefix="/dfm")
 
 # Stockage en mémoire des statuts des jobs (fallback)
 _jobs: dict[str, str] = {}
@@ -69,6 +74,34 @@ def start() -> tuple[dict, int]:
     return jsonify({"job_id": job.id, "status": "queued"}), 202
 
 
+@dfm_public_bp.post("/start")
+def public_start() -> tuple[dict, int]:
+    """Endpoint legacy: lance une analyse DFM."""
+    data = request.get_json(silent=True) or {}
+    file_id = data.get("file_id")
+    material = data.get("material") or data.get("material_profile_id")
+    axis = data.get("axis")
+    invert = bool(data.get("invert")) if "invert" in data else False
+    tolerance = data.get("tolerance")
+    if not file_id or not material or not axis:
+        return jsonify({"error": "file_id, material et axis requis"}), 400
+    if not get_profile(material):
+        return jsonify({"error": "unknown_material"}), 400
+    from app.storage.storage import Storage
+
+    step_path = Storage.get_step_path(file_id)
+    if not step_path or not os.path.isfile(step_path):
+        return jsonify({"error": "step_not_found"}), 404
+    job = dfm_run.delay(
+        file_id=file_id,
+        material_profile_id=material,
+        axis=axis,
+        invert=invert,
+        tolerance=tolerance,
+    )
+    return jsonify({"job_id": job.id, "status": "queued"}), 202
+
+
 @dfm_bp.get("/status")
 def status() -> tuple[dict, int]:
     """Renvoie l'état du job DFM."""
@@ -120,6 +153,17 @@ def result() -> tuple[dict, int]:
         jsonify({"job_id": job_id, "status": state, "summary": {}, "issues": []}),
         200,
     )
+
+
+@dfm_public_bp.get("/report/<file_id>")
+def public_report(file_id: str):
+    """Retourne le report.json pour un file_id donné."""
+    path = os.path.join("static", "dfm", file_id, "report.json")
+    if not os.path.isfile(path):
+        return jsonify({"error": "not_found"}), 404
+    with open(path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    return jsonify(data), 200
 
 
 @debug_bp.get("/debug/file/<file_id>")

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "dev": "vite build --watch",
     "postinstall": "npm run build",
     "test:e2e": "playwright test",
-    "test:e2e:headed": "PWDEBUG=1 playwright test"
+    "test:e2e:headed": "PWDEBUG=1 playwright test",
+    "smoke:dfm": "pytest tests/test_dfm_smoke.py -q"
   },
   "keywords": [],
   "author": "",

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -77,6 +77,31 @@ async function pollJobStatus(jobId, onUpdate, onDone, onError) {
   step();
 }
 
+function pollReport(fileId, onDone, onError) {
+  const started = Date.now();
+  async function step() {
+    try {
+      const res = await fetch(`/dfm/report/${encodeURIComponent(fileId)}`);
+      if (res.status === 200) {
+        const data = await res.json().catch(() => ({}));
+        onDone?.(data);
+        return;
+      }
+      if (res.status !== 404) {
+        throw new Error(`HTTP ${res.status}`);
+      }
+    } catch (e) {
+      console.error("poll report error", e);
+    }
+    if (Date.now() - started > 120000) {
+      onError?.();
+      return;
+    }
+    setTimeout(step, 2500);
+  }
+  step();
+}
+
 function showMaterialModal() {
   if (!window.bootstrap) {
     console.error("Bootstrap non chargé");
@@ -423,7 +448,7 @@ class DFMOrchestrator {
       return;
     }
     if (this.state.axisConfirmed){
-      this.startAnalysis();
+      this.startDFM();
     }
   }
 
@@ -446,17 +471,16 @@ class DFMOrchestrator {
       return;
     }
 
-    const axisVec = this.demouldAxis
-      ? [this.demouldAxis.x, this.demouldAxis.y, this.demouldAxis.z]
-      : null;
+    const axis = this.axisSelection?.axis || 'Z';
     const payload = {
       file_id: fileId,
-      material_profile_id: profile.id || profile.material_profile_id || profile,
-      axis: axisVec,
+      material: profile.id || profile.material_profile_id || profile,
+      axis,
       invert: this.axisSelection?.invert ?? false,
     };
 
     UI.setLoading(true);
+    this.state.running = true;
     dbg('DFM start: ready to send payload', payload);
     eventBus.publish('dfm:start', payload);
   }
@@ -653,14 +677,14 @@ if (typeof window !== 'undefined') {
 
 eventBus.subscribe('dfm:start', async (payload) => {
   try {
-    const res = await fetch('/api/dfm/start', {
+    const res = await fetch('/dfm/start', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload)
     });
 
     if (res.status === 404) {
-      UI.err("Endpoint /api/dfm/start introuvable (vérifier blueprint/url_prefix)");
+      UI.err("Endpoint /dfm/start introuvable");
       console.error('dfm:start 404');
       UI.setLoading(false);
       return;
@@ -673,34 +697,28 @@ eventBus.subscribe('dfm:start', async (payload) => {
       return;
     }
 
-    const data = await res.json().catch(() => ({}));
-    const jobId = data.job_id;
-    dbg('dfm:start job', jobId, data);
-    if (!jobId) {
-      UI.err('Réponse invalide (job_id manquant)');
-      UI.setLoading(false);
-      return;
-    }
-
-    pollJobStatus(
-      jobId,
-      (s) => {
-        if (s.status === 'queued') {
-          StatusUI.set('En file d’attente…');
-        } else if (s.status === 'running') {
-          const label = s.step ? `Analyse en cours… (${s.step})` : 'Analyse en cours…';
-          StatusUI.set(label);
-          if (typeof s.progress === 'number') UI.progress(s.progress);
+    await res.json().catch(() => ({}));
+    StatusUI.set('Analyse en cours…');
+    pollReport(
+      payload.file_id,
+      (data) => {
+        if (data.status === 'error') {
+          StatusUI.set('Analyse échouée');
+          UI.err(data.message || 'Analyse échouée');
+        } else {
+          StatusUI.set('Analyse terminée');
+          window.renderDFMResults?.({
+            score: data.score,
+            recommendations: data.recommendations || [],
+            metrics: data.metrics || {},
+          });
         }
-      },
-      () => {
-        StatusUI.set('Analyse terminée');
         UI.setLoading(false);
         orchestrator.state.running = false;
       },
       () => {
-        StatusUI.set('Analyse échouée');
-        UI.err('Analyse échouée');
+        StatusUI.set('Analyse trop longue');
+        UI.err('Analyse trop longue / réessaie');
         UI.setLoading(false);
         orchestrator.state.running = false;
       }

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -2,15 +2,21 @@
 
 from celery import shared_task
 
-from app.dfm.dfm_analyzer import run_dfm
+from app.dfm.dfm_analyzer import run_dfm, analyze_dfm
 from app.material_profiles import get_profile
+
+import json
+import os
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 @shared_task(bind=True, name="tasks.dfm.dfm_run")
-def dfm_run(self, file_id, material_profile_id, axis, invert=False):
-    """Run the DFM analysis for a given STEP file."""
+def dfm_run(self, file_id, material_profile_id, axis, invert=False, tolerance=None):
+    """Run the DFM analysis for a given STEP file and write report.json."""
     # >>> CADLYTICS PATCH: RESOLVE STEP (BEGIN)
-    from app.storage.storage import Storage, os
+    from app.storage.storage import Storage
 
     step_path = Storage.get_step_path(file_id)
     if not (step_path and os.path.isfile(step_path)):
@@ -19,6 +25,7 @@ def dfm_run(self, file_id, material_profile_id, axis, invert=False):
     profile = get_profile(material_profile_id)
     if profile is None:
         raise ValueError("unknown_material_profile")
+
     dfm_input = {
         "file_id": file_id,
         "step_path": step_path,
@@ -26,4 +33,56 @@ def dfm_run(self, file_id, material_profile_id, axis, invert=False):
         "invert": invert,
         "material_profile": profile.model_dump(),
     }
-    return run_dfm(dfm_input, progress_cb=None, fast_mode=False)
+
+    # Generate viewer artefacts (heatmaps, thumbnails...)
+    run_dfm(dfm_input, progress_cb=None, fast_mode=False)
+
+    # Full analysis for metrics/recommendations
+    axis_vec = _axis_to_dict(axis, invert)
+    try:
+        report = analyze_dfm(step_path, axis_vec, profile.id)
+        per_face = getattr(report, "thickness_per_face", []) or []
+        max_t = max((v.get("value", 0.0) for v in per_face), default=0.0)
+        recs = [
+            {
+                "id": i.issue_type,
+                "level": i.severity,
+                "message": i.recommendation or i.description,
+            }
+            for i in getattr(report, "geometry_issues", [])
+        ]
+        report_data = {
+            "status": "done",
+            "score": int(getattr(report, "moldability_rating", 0) * 10),
+            "recommendations": recs,
+            "metrics": {
+                "min_thickness_mm": float(getattr(report, "min_thickness", 0.0)),
+                "max_thickness_mm": float(max_t),
+                "avg_thickness_mm": float(getattr(report, "avg_thickness", 0.0)),
+                "undercuts_count": int(
+                    sum(1 for i in getattr(report, "geometry_issues", []) if i.issue_type == "undercut")
+                ),
+            },
+        }
+    except Exception as exc:  # pragma: no cover - robustness
+        report_data = {"status": "error", "message": str(exc)}
+
+    out_dir = os.path.join("static", "dfm", file_id)
+    os.makedirs(out_dir, exist_ok=True)
+    report_path = os.path.join(out_dir, "report.json")
+    with open(report_path, "w", encoding="utf-8") as fh:
+        json.dump(report_data, fh)
+    logger.info("DFM written \u2192 %s", report_path)
+
+    return report_data
+
+
+def _axis_to_dict(axis, invert):
+    """Normalize axis/invert to a dict understood by analyze_dfm."""
+    a = (axis or "z").lower()
+    mul = -1.0 if invert else 1.0
+    if a == "x":
+        return {"x": mul, "y": 0.0, "z": 0.0}
+    if a == "y":
+        return {"x": 0.0, "y": mul, "z": 0.0}
+    return {"x": 0.0, "y": 0.0, "z": mul}

--- a/tests/test_dfm_public_endpoints.py
+++ b/tests/test_dfm_public_endpoints.py
@@ -1,0 +1,58 @@
+import json
+import json
+import json
+import pathlib
+import types
+import shutil
+
+from flask import Flask
+
+from api.dfm import dfm_public_bp
+from app.storage.storage import Storage
+import app.api.dfm_routes as routes
+
+
+def _setup_storage(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    uploads.mkdir()
+    monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
+    monkeypatch.setenv("FILES_DB_PATH", str(tmp_path / "files.sqlite"))
+    step_file = uploads / "f.step"
+    step_file.write_text("ISO-10303-21;")
+    Storage.save_step_record("f", "f.step", str(step_file), step_file.stat().st_size)
+
+
+def test_public_start(tmp_path, monkeypatch):
+    _setup_storage(tmp_path, monkeypatch)
+
+    def fake_delay(**kwargs):
+        return types.SimpleNamespace(id="job1")
+
+    monkeypatch.setattr(routes.dfm_run, "delay", fake_delay)
+
+    app = Flask(__name__)
+    app.register_blueprint(dfm_public_bp)
+    client = app.test_client()
+
+    resp = client.post("/dfm/start", json={"file_id": "f", "material": "ABS", "axis": "Z"})
+    assert resp.status_code == 202
+    assert resp.get_json()["job_id"] == "job1"
+
+
+def test_public_report(tmp_path):
+    app = Flask(__name__)
+    app.register_blueprint(dfm_public_bp)
+    client = app.test_client()
+
+    report_dir = pathlib.Path("static/dfm/f")
+    report_dir.mkdir(parents=True, exist_ok=True)
+    (report_dir / "report.json").write_text(json.dumps({"status": "done"}))
+
+    resp = client.get("/dfm/report/f")
+    assert resp.status_code == 200
+    assert resp.get_json()["status"] == "done"
+
+    missing = client.get("/dfm/report/unknown")
+    assert missing.status_code == 404
+
+    shutil.rmtree(report_dir.parent)

--- a/tests/test_dfm_smoke.py
+++ b/tests/test_dfm_smoke.py
@@ -1,0 +1,99 @@
+import json
+import time
+import types
+from pathlib import Path
+import sys
+
+from flask import Flask
+
+from api.contract import api_contract_bp
+
+
+def test_dfm_smoke(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    outputs = tmp_path / "converted"
+    uploads.mkdir()
+    outputs.mkdir()
+    monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
+    monkeypatch.setenv("OUTPUT_FOLDER", str(outputs))
+    monkeypatch.setenv("FILES_DB_PATH", str(tmp_path / "files.sqlite"))
+
+    # Stub Celery task module before importing routes
+    report_template = {
+        "status": "done",
+        "score": 72,
+        "recommendations": [
+            {
+                "id": "thickness_uniformity",
+                "level": "warning",
+                "message": "Épaisseur non uniforme.",
+            }
+        ],
+        "metrics": {
+            "min_thickness_mm": 1.2,
+            "max_thickness_mm": 3.8,
+            "avg_thickness_mm": 2.4,
+            "undercuts_count": 0,
+        },
+    }
+
+    def stub_delay(file_id, **kwargs):
+        out_dir = Path("static/dfm") / file_id
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "report.json").write_text(json.dumps(report_template))
+        return types.SimpleNamespace(id="job1")
+
+    tasks_pkg = types.ModuleType("tasks")
+    dfm_mod = types.ModuleType("tasks.dfm")
+    dfm_mod.dfm_run = types.SimpleNamespace(delay=stub_delay)
+    tasks_pkg.dfm = dfm_mod
+    sys.modules["tasks"] = tasks_pkg
+    sys.modules["tasks.dfm"] = dfm_mod
+
+    import app.api.dfm_routes as routes
+
+    app = Flask(__name__)
+    app.register_blueprint(api_contract_bp)
+    app.register_blueprint(routes.dfm_public_bp)
+    client = app.test_client()
+
+    # stub converter
+    def fake_run(cmd, capture_output, text, timeout):
+        Path(cmd[2]).write_text("xkt")
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "generate_thumbnails.generate_thumbnails",
+        lambda step_path, out_dir: {"iso": str(Path(out_dir) / "preview.png")},
+    )
+
+    sample = Path("tests/sample.step")
+    with sample.open("rb") as fh:
+        up = client.post("/api/simple/upload", data={"file": (fh, "sample.step")})
+    assert up.status_code == 200
+    file_id = up.get_json()["file_id"]
+
+    conv = client.post("/api/simple/convert", json={"file_id": file_id})
+    xkt_url = conv.get_json()["xkt_path"]
+    print("XKT viewer URL:", xkt_url)
+
+    start = client.post(
+        "/dfm/start",
+        json={"file_id": file_id, "material": "ABS", "axis": "Z"},
+    )
+    assert start.status_code == 202
+
+    for _ in range(60):
+        rep = client.get(f"/dfm/report/{file_id}")
+        if rep.status_code == 200:
+            data = rep.get_json()
+            break
+        time.sleep(0.5)
+    else:
+        raise AssertionError("report timeout")
+
+    assert data["status"] == "done"
+    assert data["score"] == 72
+    assert data["recommendations"]
+    assert data["metrics"]

--- a/web.py
+++ b/web.py
@@ -51,7 +51,7 @@ from dotenv import load_dotenv
 from kombu.exceptions import OperationalError as KombuOperationalError
 from redis.exceptions import ConnectionError as RedisConnectionError
 from storage.s3 import get_signed_url
-from api.dfm import dfm_bp, debug_bp
+from api.dfm import dfm_bp, debug_bp, dfm_public_bp
 from api.contract import api_contract_bp
 from errors import register_error_handlers
 
@@ -83,6 +83,7 @@ register_error_handlers(app)
 # Enregistre les blueprints de l’API
 app.register_blueprint(dfm_bp)
 app.register_blueprint(debug_bp)
+app.register_blueprint(dfm_public_bp)
 app.register_blueprint(api_contract_bp)
 
 # Lie Celery au contexte Flask (pas d’alias inutile)


### PR DESCRIPTION
## Summary
- add Celery task adapter writing `static/dfm/<file_id>/report.json` with metrics and recommendations
- expose `/dfm/start` and `/dfm/report/<file_id>` endpoints via new blueprint
- register public DFM blueprint in app and cover with tests
- route front-end orchestrator to poll `/dfm/report/<file_id>` and render results
- add `npm run smoke:dfm` to exercise upload→convert→report pipeline

## Testing
- `npm run smoke:dfm`
- `pytest tests/test_dfm_public_endpoints.py tests/test_dfm_start_stub.py -q`
- `pytest tests/test_dfm_api.py -q` *(fails: upload and health endpoints missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a21f380483338bbc4c15b8458dec