### PR TITLE
Fix viewer load and require explicit material choice

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -551,9 +551,8 @@ async function loadXKTFromConvertResponse(response) {
 
     const head = await fetch(xktUrl, { method: 'HEAD' });
     if (!head.ok) throw new Error(`XKT not available: ${head.status}`);
-
-    if (viewer?.loadXKT) await viewer.loadXKT(xktUrl);
-    else if (window.loadXKT) await window.loadXKT(xktUrl);
+    const model = await xktLoader.load({ id: fileId, src: xktUrl });
+    viewer.model = model;
     console.info('[VIEW] XKT loaded', xktUrl);
   } catch (e) {
     console.error('[VIEW] Visualization error', e);

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -483,10 +483,11 @@ class DFMOrchestrator {
 
   async handleAnalyzeClick(){
     console.info('[dfm] analyse demandée');
-    if (!window.currentFileId) { console.info('[dfm] demande fichier'); openMaterialModal(); return; }
+    const fileId = this.resolveFileId();
+    if (!fileId) { console.info('[dfm] demande fichier'); openMaterialModal(); return; }
     if (!materialIsConfirmed()) { console.info('[dfm] demande matière'); openMaterialModal(); return; }
     if (!axisIsValidated()) { console.info('[dfm] demande axe'); showAxisPanel(); return; }
-    this.setFileId(window.currentFileId);
+    this.setFileId(fileId);
     await this.startDFM();
   }
 

--- a/static/js/criteria-modal.js
+++ b/static/js/criteria-modal.js
@@ -241,10 +241,15 @@ function validateForm() {
 // Récupère toutes les valeurs du formulaire matière
 function collectMaterialFromForm() {
   const form = document.getElementById("materialQuestionnaireForm");
-  if (!form) return {};
+  if (!form) return null;
   const fd = new FormData(form);
+  const resin = fd.get("resin");
+  if (!resin) {
+    toast("Choisis une matière avant de valider");
+    return null;
+  }
   const profile = {
-    id: fd.get("resin") || "GENERIC",
+    id: resin,
     draft_min_deg: parseFloat(fd.get("draft_min_deg")) || 1.0,
   };
   fd.forEach((v, k) => {
@@ -295,6 +300,10 @@ document.addEventListener("DOMContentLoaded", () => {
       }
       // Émission de l'event material:selected
       const materialProfile = collectMaterialFromForm();
+      if (!materialProfile) {
+        e.preventDefault();
+        return;
+      }
       materialProfile.criteria = res.payload;
       console.debug('[DFM] material:selected emit', materialProfile);
       window.dispatchEvent(new CustomEvent('material:selected', { detail: { materialProfile }}));


### PR DESCRIPTION
## Summary
- enforce real material selection with validation and remove fallback to GENERIC
- ensure DFM orchestrator resolves fileId and shows axis picker
- load XKT models via xeokit loader so viewer displays converted parts

## Testing
- `npm run build`
- `pytest tests/test_dfm_smoke.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c403f1009c8333acf1e85c8ef606d1