### PR TITLE
Handle xeokit output flag variants and robust viewer loader

### DIFF
--- a/app/api/contract_routes.py
+++ b/app/api/contract_routes.py
@@ -88,16 +88,15 @@ def convert_step() -> tuple[Any, int]:
         if not file_id:
             return jsonify({"error": "missing_file_id"}), 400
 
-        step_path = Storage.get_step_path(file_id)
-        if not step_path or not os.path.exists(step_path):
+        step_in_path = Storage.get_step_path(file_id)
+        if not step_in_path or not os.path.exists(step_in_path):
             return jsonify({"error": "missing_or_unknown_file_id"}), 400
 
         os.makedirs(OUTPUT_FOLDER, exist_ok=True)
-        xkt_path = os.path.join(OUTPUT_FOLDER, f"{file_id}.xkt")
+        xkt_out_path = os.path.join(OUTPUT_FOLDER, f"{file_id}.xkt")
         preview_path = os.path.join(OUTPUT_FOLDER, f"{file_id}.png")
-
-        if os.path.exists(xkt_path):
-            current_app.logger.info(f"[convert] XKT ready /models/{file_id}.xkt")
+        if os.path.exists(xkt_out_path):
+            current_app.logger.info(f"[convert] XKT ready {xkt_out_path}")
             try:
                 History.record_convert(file_id, 0)
             except Exception as exc:  # fail soft
@@ -113,22 +112,42 @@ def convert_step() -> tuple[Any, int]:
                 200,
             )
 
-        xeokit_bin = os.environ.get("XEOKIT_CONVERT") or "xeokit-convert"
-        cmd = [xeokit_bin, "--out", xkt_path, step_path]
-        t0 = time.time()
-        res = subprocess.run(cmd, capture_output=True, text=True, timeout=180)
-        duration_ms = (time.time() - t0) * 1000
-        if res.returncode != 0:
-            current_app.logger.error(
-                f"[convert] fail rc={res.returncode} stderr={res.stderr[:4000]}"
-            )
-            return jsonify({"error": "convert_failed", "stderr": res.stderr}), 500
+        xeokit_bin_path = os.environ.get("XEOKIT_CONVERT") or "xeokit-convert"
 
-        current_app.logger.info(f"[convert] XKT ready /models/{file_id}.xkt")
+        def _run_convert(cmd: list[str]):
+            return subprocess.run(cmd, capture_output=True, text=True, timeout=300)
+
+        tried: list[str] = []
+        res = None
+        t0 = time.time()
+        for variant in (
+            ["--output", xkt_out_path],
+            ["-o", xkt_out_path],
+            ["--out", xkt_out_path],
+        ):
+            cmd = [xeokit_bin_path, *variant, step_in_path]
+            tried.append(" ".join(cmd))
+            try:
+                res = _run_convert(cmd)
+            except Exception as exc:  # pragma: no cover
+                current_app.logger.error("[convert] exception %s for cmd=%s", exc, cmd)
+                return jsonify({"error": "convert_failed", "stderr": str(exc)}), 500
+            if res.returncode == 0:
+                break
+        else:
+            stderr = res.stderr if res else ""
+            current_app.logger.error(
+                f"[convert] failed. tried={tried} stderr={stderr[:3000]}"
+            )
+            return jsonify({"error": "convert_failed", "stderr": stderr}), 500
+
+        duration_ms = (time.time() - t0) * 1000
+
+        current_app.logger.info(f"[convert] XKT ready {xkt_out_path}")
 
         try:
             from generate_thumbnails import generate_thumbnails
-            thumbs = generate_thumbnails(step_path, OUTPUT_FOLDER)
+            thumbs = generate_thumbnails(step_in_path, OUTPUT_FOLDER)
             preview_path = thumbs.get("iso", preview_path)
         except Exception as exc:  # pragma: no cover
             current_app.logger.warning(

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -163,20 +163,21 @@ function axisIsValidated(){
   return !!window.selectedAxis;
 }
 
-function showAxisPanel() {
+function showAxisPanelIfReady() {
   if (!axisPanel) return;
   if (!window.currentFileId || !materialIsConfirmed()) return;
   axisPanel.style.display = "";
 }
 
-window.addEventListener("material:confirmed", () => { showAxisPanel(); });
+window.addEventListener("material:confirmed", showAxisPanelIfReady);
+window.addEventListener("material:selected", showAxisPanelIfReady);
 window.addEventListener("axis:confirmed", (e) => { window.selectedAxis = e?.detail; });
 
 if (btnAnalyser) {
   btnAnalyser.addEventListener("click", async () => {
     if (!window.currentFileId) { openMaterialModal?.(); return; }
     if (!materialIsConfirmed()) { openMaterialModal?.(); return; }
-    if (!axisIsValidated()) { showAxisPanel(); return; }
+    if (!axisIsValidated()) { showAxisPanelIfReady(); return; }
     const payload = {
       file_id: window.currentFileId,
       axis: window.selectedAxis?.axis || "auto",
@@ -525,7 +526,7 @@ class DFMOrchestrator {
     const fileId = this.resolveFileId();
     if (!fileId) { console.info('[dfm] demande fichier'); openMaterialModal(); return; }
     if (!materialIsConfirmed()) { console.info('[dfm] demande matière'); openMaterialModal(); return; }
-    if (!axisIsValidated()) { console.info('[dfm] demande axe'); showAxisPanel(); return; }
+    if (!axisIsValidated()) { console.info('[dfm] demande axe'); showAxisPanelIfReady(); return; }
     this.setFileId(fileId);
     await this.startDFM();
   }

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -1,34 +1,39 @@
 import { Viewer, XKTLoaderPlugin }
   from "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@2/dist/xeokit-sdk.es.js";
 
-// Instancie le viewer v2 sans plugins v1
-const viewer = new Viewer({ canvasId: "viewer3d" });
-const xktLoader = new XKTLoaderPlugin(viewer);
+// Viewer Xeokit v2 avec loader XKT et recherche d'URL robuste
+window.viewerAdapter = (() => {
+  const viewer = window._viewer || new Viewer({ canvasId: "viewerCanvas" });
+  const xktLoader = new XKTLoaderPlugin(viewer);
 
-window.viewerAdapter = {
-  viewer,
-  async loadFromFileId(fileId) {
-    const candidates = [`/models/${fileId}.xkt`, `/static/converted/${fileId}.xkt`];
-    let chosen = null;
-    for (const url of candidates) {
+  async function pickReachableUrl(id) {
+    const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
+    for (const u of urls) {
       try {
-        const h = await fetch(url, { method: "HEAD", cache: "no-store" });
-        console.log("[viewer] HEAD", url, h.status);
-        if (h.ok) { chosen = url; break; }
-      } catch (_) {}
+        const h = await fetch(u, { method: "HEAD", cache: "no-store" });
+        console.log("[viewer] HEAD", u, h.status);
+        if (h.ok) return u;
+      } catch {}
     }
-    if (!chosen) { console.error("[viewer] no XKT reachable", candidates); return false; }
-    console.log("[viewer] load", chosen);
+    return null;
+  }
+
+  async function loadFromFileId(id) {
+    const url = await pickReachableUrl(id);
+    if (!url) { console.error("[viewer] no reachable XKT"); return false; }
+    console.log("[viewer] load", url);
     console.time("[viewer] xkt load");
-    const model = await xktLoader.load({ src: chosen });
+    const model = await xktLoader.load({ src: url });
     console.timeEnd("[viewer] xkt load");
     const aabb = (model && model.aabb) || viewer.scene.aabb;
     if (aabb) viewer.cameraControl.fit(aabb);
     console.log("[viewer] fit ok", aabb);
-    try { viewer.canvas.canvas.style.background = "#222"; } catch (e) {}
+    try { viewer.canvas.canvas.style.background = "#e9ecef"; } catch (e) {}
     return true;
   }
-};
+
+  return { viewer, loadFromFileId };
+})();
 
 export default window.viewerAdapter;
 


### PR DESCRIPTION
## Summary
- allow xeokit-convert run with --output/-o/--out fallback
- refactor viewer adapter to use xeokit v2 with URL fallback and logging
- auto-convert STEP files after upload and show axis panel once material confirmed

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask'; 15 errors during collection)*

------
https://chatgpt.com/codex/tasks/task_e_68c41e1e67e88333b52b555bf8cfc933