### PR TITLE
Add xkt viewer canvas and robust convert route

### DIFF
--- a/app/api/contract_routes.py
+++ b/app/api/contract_routes.py
@@ -21,19 +21,6 @@ MAX_UPLOAD_MB = int(os.environ.get("MAX_UPLOAD_MB", "300"))
 api_contract_bp = Blueprint("api_contract", __name__, url_prefix="/api/simple")
 
 
-@api_contract_bp.record_once
-def _register_models(state) -> None:
-    app = state.app
-
-    @app.get("/models/<path:filename>")
-    def _models(filename: str):
-        path = os.path.join(OUTPUT_FOLDER, filename)
-        if not os.path.isfile(path):
-            return jsonify({"error": "not_found"}), 404
-        mimetype = "model/xkt" if filename.endswith(".xkt") else None
-        return send_from_directory(OUTPUT_FOLDER, filename, mimetype=mimetype)
-
-
 @api_contract_bp.post("/upload")
 def upload_step() -> tuple[Any, int]:
     file = request.files.get("file")
@@ -101,24 +88,14 @@ def convert_step() -> tuple[Any, int]:
                 History.record_convert(file_id, 0)
             except Exception as exc:  # fail soft
                 current_app.logger.warning("history convert failed for %s: %s", file_id, exc)
-            return (
-                jsonify(
-                    {
-                        "file_id": file_id,
-                        "xkt_url": f"/models/{file_id}.xkt",
-                        "preview_png": f"/models/{file_id}.png" if os.path.exists(preview_path) else None,
-                    }
-                ),
-                200,
-            )
+            return jsonify({"file_id": file_id, "xkt_url": f"/models/{file_id}.xkt"}), 200
 
         xeokit_bin_path = os.environ.get("XEOKIT_CONVERT") or "xeokit-convert"
 
-        def _run_convert(cmd: list[str]):
+        def _run(cmd: list[str]):
             return subprocess.run(cmd, capture_output=True, text=True, timeout=300)
 
         tried: list[str] = []
-        res = None
         t0 = time.time()
         for variant in (
             ["--output", xkt_out_path],
@@ -127,19 +104,17 @@ def convert_step() -> tuple[Any, int]:
         ):
             cmd = [xeokit_bin_path, *variant, step_in_path]
             tried.append(" ".join(cmd))
-            try:
-                res = _run_convert(cmd)
-            except Exception as exc:  # pragma: no cover
-                current_app.logger.error("[convert] exception %s for cmd=%s", exc, cmd)
-                return jsonify({"error": "convert_failed", "stderr": str(exc)}), 500
+            res = _run(cmd)
             if res.returncode == 0:
                 break
         else:
-            stderr = res.stderr if res else ""
             current_app.logger.error(
-                f"[convert] failed. tried={tried} stderr={stderr[:3000]}"
+                f"[convert] failed tried={tried} stderr={res.stderr[:2000]}"
             )
-            return jsonify({"error": "convert_failed", "stderr": stderr}), 500
+            return (
+                jsonify({"error": "convert_failed", "stderr": res.stderr}),
+                500,
+            )
 
         duration_ms = (time.time() - t0) * 1000
 
@@ -160,16 +135,7 @@ def convert_step() -> tuple[Any, int]:
         except Exception as exc:  # fail soft
             current_app.logger.warning("history convert failed for %s: %s", file_id, exc)
 
-        return (
-            jsonify(
-                {
-                    "file_id": file_id,
-                    "xkt_url": f"/models/{file_id}.xkt",
-                    "preview_png": f"/models/{file_id}.png" if os.path.exists(preview_path) else None,
-                }
-            ),
-            200,
-        )
+        return jsonify({"file_id": file_id, "xkt_url": f"/models/{file_id}.xkt"}), 200
     except Exception as exc:  # pragma: no cover
         current_app.logger.error("[convert] unexpected error: %s", exc)
         return jsonify({"error": "convert_failed", "message": str(exc)}), 500
@@ -250,3 +216,11 @@ def get_report(file_id: str) -> tuple[Any, int]:
     with open(path, "r", encoding="utf-8") as fh:
         data = json.load(fh)
     return jsonify(data), 200
+
+
+# PATCH START: serve converted models
+@api_contract_bp.route('/models/<path:filename>', methods=['GET', 'HEAD'])
+def serve_models(filename):
+    output_dir = os.environ.get('OUTPUT_FOLDER', '/tmp/converted')
+    return send_from_directory(output_dir, filename)
+# PATCH END

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1433,3 +1433,9 @@ body {
   }
 }
 
+/* PATCH START: viewer canvas css */
+.xkt-canvas{width:100%;height:100%;display:block;}
+#viewer-wrapper,.viewer-wrapper,[data-viewer="xkt"]{min-height:420px;position:relative;}
+#dfmAxisPanel,#axis-panel{display:none;} /* anti-flash: axe caché au chargement */
+/* PATCH END */
+

--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -16,10 +16,11 @@ if (typeof window !== "undefined") {
   };
 }
 
-// Sélecteurs compatibles (deux variantes d'ID)
-const btnVisualiser = document.querySelector("#btn-visualiser, #visualizeBtn");
-const btnAnalyser   = document.querySelector("#analyzeBtn, #btn-analyser");
-const axisPanel     = document.querySelector("#dfmAxisPanel, #axis-panel");
+// PATCH START: selectors
+const btnVisualiser = document.querySelector('#btn-visualiser, #visualizeBtn');
+const btnAnalyser   = document.querySelector('#analyzeBtn, #btn-analyser');
+const axisPanel     = document.querySelector('#dfmAxisPanel, #axis-panel');
+// PATCH END
 
 // État initial : cacher l'axe mais laisser Analyser cliquable
 if (axisPanel) axisPanel.style.display = "none";
@@ -155,23 +156,22 @@ function openMaterialModal(){
   showMaterialModal();
 }
 
-function materialIsConfirmed(){
-  return !!window.selectedMaterial;
+// PATCH START: show axis after material confirmed
+function materialIsConfirmed(){ return !!window.selectedMaterial; }
+function showAxisPanelIfReady(){
+  if (!axisPanel) return;
+  if (!window.currentFileId || !materialIsConfirmed()) return;
+  axisPanel.style.display = '';
 }
+window.addEventListener('material:confirmed', showAxisPanelIfReady);
+window.addEventListener('material:selected',  showAxisPanelIfReady); // compat
+// PATCH END
+
+window.addEventListener('axis:confirmed', (e) => { window.selectedAxis = e?.detail; });
 
 function axisIsValidated(){
   return !!window.selectedAxis;
 }
-
-function showAxisPanelIfReady() {
-  if (!axisPanel) return;
-  if (!window.currentFileId || !materialIsConfirmed()) return;
-  axisPanel.style.display = "";
-}
-
-window.addEventListener("material:confirmed", showAxisPanelIfReady);
-window.addEventListener("material:selected", showAxisPanelIfReady);
-window.addEventListener("axis:confirmed", (e) => { window.selectedAxis = e?.detail; });
 
 if (btnAnalyser) {
   btnAnalyser.addEventListener("click", async () => {
@@ -869,34 +869,32 @@ function getTolerance() {
   return Number.isFinite(v) ? v : 0.1;
 }
 
-// Autoconversion post-upload
-window.addEventListener("dfm:fileReady", async (e) => {
+// PATCH START: autoconvert on file ready
+window.addEventListener('dfm:fileReady', async (e) => {
   const fid = (e?.detail && e.detail.fileId) || window.currentFileId;
   if (!fid) return;
-  console.log("[auto] convert start", fid);
-  const r = await fetch("/api/simple/convert", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
+  const r = await fetch('/api/simple/convert', {
+    method:'POST', headers:{'Content-Type':'application/json'},
     body: JSON.stringify({ file_id: fid, tolerance: getTolerance?.() })
   });
-  console.log("[auto] convert status", r.status);
-  try { console.log("[auto] convert payload", await r.json()); } catch {}
+  console.log('[auto] convert status', r.status);
+  try { console.log('[auto] payload', await r.json()); } catch {}
   await (window.viewerAdapter?.loadFromFileId?.(fid));
 });
+// PATCH END
 
-// Bouton "Visualiser"
+// PATCH START: visualiser button
 if (btnVisualiser) {
-  btnVisualiser.addEventListener("click", async () => {
+  btnVisualiser.addEventListener('click', async () => {
     const fid = window.currentFileId;
-    if (!fid) { console.warn("[visualiser] no fileId"); return; }
-    console.log("[visualiser] start", fid);
-    const r = await fetch("/api/simple/convert", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
+    if (!fid) { console.warn('[visualiser] no fileId'); return; }
+    const r = await fetch('/api/simple/convert', {
+      method:'POST', headers:{'Content-Type':'application/json'},
       body: JSON.stringify({ file_id: fid, tolerance: getTolerance?.() })
     });
-    console.log("[visualiser] convert status", r.status);
-    try { console.log("[visualiser] payload", await r.json()); } catch {}
+    console.log('[visualiser] convert status', r.status);
+    try { console.log('[visualiser] payload', await r.json()); } catch {}
     await (window.viewerAdapter?.loadFromFileId?.(fid));
   });
 }
+// PATCH END

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -1,47 +1,43 @@
 import { Viewer, XKTLoaderPlugin }
   from "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@2/dist/xeokit-sdk.es.js";
 
-// Viewer Xeokit v2 avec loader XKT et recherche d'URL robuste
-window.viewerAdapter = (() => {
-  const viewer = window._viewer || new Viewer({ canvasId: "viewerCanvas" });
-  const xktLoader = new XKTLoaderPlugin(viewer);
+// PATCH START: init with canvasElement
+const _canvas = document.getElementById('xktCanvas');
+if (!_canvas) { console.error('[viewer] missing #xktCanvas'); }
+const _viewer = new Viewer({ canvasElement: _canvas });
+const xktLoader = new XKTLoaderPlugin(_viewer);
+try { _viewer.canvas.canvas.style.background = '#e9ecef'; } catch(e){}
+// PATCH END
 
-  async function pickReachableUrl(id) {
-    const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
-    for (const u of urls) {
-      try {
-        const h = await fetch(u, { method: "HEAD", cache: "no-store" });
-        console.log("[viewer] HEAD", u, h.status);
-        if (h.ok) return u;
-      } catch {}
-    }
-    return null;
-  }
-
-  async function loadFromFileId(id) {
-    const url = await pickReachableUrl(id);
-    if (!url) { console.error("[viewer] no reachable XKT"); return false; }
-    console.log("[viewer] load", url);
-    console.time("[viewer] xkt load");
-    const model = await xktLoader.load({ src: url });
-    console.timeEnd("[viewer] xkt load");
-    const aabb = (model && model.aabb) || viewer.scene.aabb;
-    if (aabb) viewer.cameraControl.fit(aabb);
-    console.log("[viewer] fit ok", aabb);
-    try { viewer.canvas.canvas.style.background = "#e9ecef"; } catch (e) {}
-    return true;
-  }
-
-  return { viewer, loadFromFileId };
-})();
-
-export default window.viewerAdapter;
-
-export async function loadCameraPresetOptional(u) {
-  try {
-    const r = await fetch(u, { cache: "no-store" });
-    return r.ok ? await r.json() : null;
-  } catch {
-    return null;
-  }
+// PATCH START: optional camera preset
+export async function loadCameraPresetOptional(u){
+  try { const r = await fetch(u, {cache:'no-store'}); return r.ok ? await r.json() : null; }
+  catch { return null; }
 }
+// PATCH END
+
+// PATCH START: loadFromFileId with /models fallback
+async function pickReachableUrl(id){
+  const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
+  for (const u of urls){
+    try { const h = await fetch(u, { method:'HEAD', cache:'no-store' });
+          console.log('[viewer] HEAD', u, h.status);
+          if (h.ok) return u; } catch {}
+  }
+  return null;
+}
+export async function loadFromFileId(fileId){
+  const url = await pickReachableUrl(fileId);
+  if (!url){ console.error('[viewer] no reachable XKT'); return false; }
+  console.log('[viewer] load', url);
+  console.time('[viewer] xkt load');
+  const model = await xktLoader.load({ src: url });
+  console.timeEnd('[viewer] xkt load');
+  const aabb = (model && model.aabb) || _viewer.scene.aabb;
+  if (aabb) _viewer.cameraControl.fit(aabb);
+  console.log('[viewer] fit ok', aabb);
+  return true;
+}
+// expose pour l’orchestrateur
+window.viewerAdapter = { viewer: _viewer, loadFromFileId };
+// PATCH END

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,9 +23,6 @@
     
     <!-- Custom CSS -->
     <link href="{{ url_for('static', filename='css/style.css') }}" rel="stylesheet">
-    <style>
-      #dfmAxisPanel, #axis-panel { display: none; }
-    </style>
     
     <!-- Favicon -->
     <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
@@ -193,8 +190,9 @@
 
     <!-- === CONTENEUR VIEWER NOUVEAU (overlay) === -->
     <div id="viewer" class="viewer-wrapper position-relative" style="height: 600px; border-radius:10px; background:#e8e9ea; overflow:hidden;">
-      <!-- Canvas -->
-      <canvas id="viewer3d" style="width:100%;height:100%;display:block;"></canvas>
+      <!-- PATCH START: viewer canvas -->
+      <canvas id="xktCanvas" class="xkt-canvas" aria-label="3D viewer"></canvas>
+      <!-- PATCH END -->
 
       <!-- Barre d’outils overlay : IDs attendus par main.js -->
       <div id="toolbar" data-viewer-required class="toolbar position-absolute" style="top:10px; left:10px; z-index:10; display:flex; gap:8px;">


### PR DESCRIPTION
## Summary
- Replace legacy canvas with `xktCanvas` and add viewer patch markers
- Append CSS for xkt canvas sizing and hide axis panel by default
- Initialize Xeokit v2 viewer with `xktCanvas` and expose `loadFromFileId`
- Hook DFM orchestrator to auto-convert and visualise uploaded files
- Make `/api/simple/convert` resilient to xeokit-convert CLI options and return served URL
- Serve converted models directly from `OUTPUT_FOLDER`

## Testing
- `pip install -r requirements.txt` *(fails: Invalid version: 'x86_64')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c6b10cb79c833383b96dac1e4dfe04