### PR TITLE
Refactor Xeokit viewer bootstrapping

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -869,32 +869,41 @@ function getTolerance() {
   return Number.isFinite(v) ? v : 0.1;
 }
 
-// PATCH START: autoconvert on file ready
-window.addEventListener('dfm:fileReady', async (e) => {
-  const fid = (e?.detail && e.detail.fileId) || window.currentFileId;
-  if (!fid) return;
-  const r = await fetch('/api/simple/convert', {
-    method:'POST', headers:{'Content-Type':'application/json'},
-    body: JSON.stringify({ file_id: fid, tolerance: getTolerance?.() })
-  });
-  console.log('[auto] convert status', r.status);
-  try { console.log('[auto] payload', await r.json()); } catch {}
-  await (window.viewerAdapter?.loadFromFileId?.(fid));
-});
-// PATCH END
+// PATCH START: visualize flow via viewerAdapter
+(function(){
+  function $(s){ return document.querySelector(s); }
+  const btnVisualiser = $('#btn-visualiser, #visualizeBtn');
 
-// PATCH START: visualiser button
-if (btnVisualiser) {
-  btnVisualiser.addEventListener('click', async () => {
-    const fid = window.currentFileId;
-    if (!fid) { console.warn('[visualiser] no fileId'); return; }
+  async function convert(fileId){
+    if (!fileId) return false;
     const r = await fetch('/api/simple/convert', {
-      method:'POST', headers:{'Content-Type':'application/json'},
-      body: JSON.stringify({ file_id: fid, tolerance: getTolerance?.() })
+      method: 'POST',
+      headers: {'Content-Type':'application/json'},
+      body: JSON.stringify({ file_id: fileId, tolerance: window.getTolerance?.() })
     });
     console.log('[visualiser] convert status', r.status);
     try { console.log('[visualiser] payload', await r.json()); } catch {}
-    await (window.viewerAdapter?.loadFromFileId?.(fid));
+    return r.ok;
+  }
+
+  async function doVisualize(fid){
+    if (!fid) { console.warn('[visualiser] no fileId'); return; }
+    if (!window.viewerAdapter?.viewer) {
+      // Si personne n'a démarré le viewer, on le fait ici
+      const canvas = document.getElementById('xktCanvas');
+      window.initViewer?.({ canvasElement: canvas });
+    }
+    await convert(fid); // idempotent: OK si déjà converti
+    await window.viewerAdapter?.loadFromFileId?.(fid);
+  }
+
+  if (btnVisualiser) {
+    btnVisualiser.addEventListener('click', () => doVisualize(window.currentFileId));
+  }
+
+  window.addEventListener('dfm:fileReady', (e) => {
+    const fid = (e?.detail && e.detail.fileId) || window.currentFileId;
+    if (fid) doVisualize(fid);
   });
-}
+})();
 // PATCH END

--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -1,13 +1,5 @@
-import { Viewer, XKTLoaderPlugin }
+import { Viewer as XEViewer, XKTLoaderPlugin as XEXKTLoaderPlugin }
   from "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@2/dist/xeokit-sdk.es.js";
-
-// PATCH START: init with canvasElement
-const _canvas = document.getElementById('xktCanvas');
-if (!_canvas) { console.error('[viewer] missing #xktCanvas'); }
-const _viewer = new Viewer({ canvasElement: _canvas });
-const xktLoader = new XKTLoaderPlugin(_viewer);
-try { _viewer.canvas.canvas.style.background = '#e9ecef'; } catch(e){}
-// PATCH END
 
 // PATCH START: optional camera preset
 export async function loadCameraPresetOptional(u){
@@ -16,73 +8,6 @@ export async function loadCameraPresetOptional(u){
 }
 // PATCH END
 
-// PATCH START: loadFromFileId with /models fallback
-async function pickReachableUrl(id){
-  const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
-  for (const u of urls){
-    try { const h = await fetch(u, { method:'HEAD', cache:'no-store' });
-          console.log('[viewer] HEAD', u, h.status);
-          if (h.ok) return u; } catch {}
-  }
-  return null;
-}
-export async function loadFromFileId(fileId){
-  const url = await pickReachableUrl(fileId);
-  if (!url){ console.error('[viewer] no reachable XKT'); return false; }
-  console.log('[viewer] load', url);
-  console.time('[viewer] xkt load');
-  const model = await xktLoader.load({ src: url });
-  console.timeEnd('[viewer] xkt load');
-  const aabb = (model && model.aabb) || _viewer.scene.aabb;
-  if (aabb) _viewer.cameraControl.fit(aabb);
-  console.log('[viewer] fit ok', aabb);
-  return true;
-}
-// expose pour l’orchestrateur
-window.viewerAdapter = { viewer: _viewer, loadFromFileId };
-// PATCH END
-// PATCH START: xeokit v2 bootstrap + robust loader
-import { Viewer, XKTLoaderPlugin } from "https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@2/dist/xeokit-sdk.es.js";
-
-(function initViewerV2(){
-  function ready(fn){ /complete|interactive/.test(document.readyState) ? fn() : document.addEventListener('DOMContentLoaded', fn); }
-  ready(() => {
-    const canvas = document.getElementById('xktCanvas');
-    if (!canvas){ console.error('initViewer failed canvas introuvable'); return; }
-
-    const viewer = new Viewer({ canvasElement: canvas });
-    const xktLoader = new XKTLoaderPlugin(viewer);
-    try { viewer.canvas.canvas.style.background = '#e9ecef'; } catch(e){}
-
-    async function pickUrl(id){
-      const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
-      for (const u of urls){
-        try { const h = await fetch(u, { method:'HEAD', cache:'no-store' });
-              console.log('[viewer] HEAD', u, h.status);
-              if (h.ok) return u; } catch {}
-      }
-      return null;
-    }
-
-    async function loadFromFileId(fileId){
-      const url = await pickUrl(fileId);
-      if (!url){ console.error('[viewer] no reachable XKT for', fileId); return false; }
-      console.log('[viewer] load', url);
-      console.time('[viewer] xkt load');
-      const model = await xktLoader.load({ src: url });
-      console.timeEnd('[viewer] xkt load');
-      const aabb = (model && model.aabb) || viewer.scene.aabb;
-      if (aabb) viewer.cameraControl.fit(aabb);
-      console.log('[viewer] fit ok', aabb);
-      return true;
-    }
-
-    // expose pour l’orchestrateur
-    window.viewerAdapter = { viewer, loadFromFileId };
-    console.log('[viewer] init ok');
-  });
-})();
-// PATCH END
 // PATCH START: visualiser flow + axis show after material
 (function(){
   function $(s){ return document.querySelector(s); }
@@ -137,3 +62,68 @@ import { Viewer, XKTLoaderPlugin } from "https://cdn.jsdelivr.net/npm/@xeokit/xe
   });
 })();
 // PATCH END
+
+// PATCH START: single-boot viewer with default canvas + robust loader
+if (!window.__XE_VIEWER_BOOT__) {
+  window.__XE_VIEWER_BOOT__ = true;
+
+  function getCanvasFromConfig(cfg = {}) {
+    return (
+      cfg.canvasElement ||
+      (cfg.canvasId && document.getElementById(cfg.canvasId)) ||
+      document.getElementById('xktCanvas')
+    );
+  }
+
+  // initViewer peut être appelée par le code existant (main.js). On la rend tolérante.
+  window.initViewer = function initViewer(cfg = {}) {
+    const canvas = getCanvasFromConfig(cfg);
+    if (!canvas) {
+      console.error('[viewer] canvas introuvable', { cfg });
+      return null;
+    }
+    const viewer = new XEViewer({ canvasElement: canvas });
+    try { viewer.canvas.canvas.style.background = '#e9ecef'; } catch (e) {}
+    const xktLoader = new XEXKTLoaderPlugin(viewer);
+
+    async function pickUrl(id) {
+      const urls = [`/models/${id}.xkt`, `/static/converted/${id}.xkt`];
+      for (const u of urls) {
+        try {
+          const h = await fetch(u, { method: 'HEAD', cache: 'no-store' });
+          console.log('[viewer] HEAD', u, h.status);
+          if (h.ok) return u;
+        } catch (_) {}
+      }
+      return null;
+    }
+
+    async function loadFromFileId(fileId) {
+      const url = await pickUrl(fileId);
+      if (!url) { console.error('[viewer] no reachable XKT for', fileId); return false; }
+      console.log('[viewer] load', url);
+      console.time('[viewer] xkt load');
+      const model = await xktLoader.load({ src: url });
+      console.timeEnd('[viewer] xkt load');
+      const aabb = (model && model.aabb) || viewer.scene.aabb;
+      if (aabb) viewer.cameraControl.fit(aabb);
+      console.log('[viewer] fit ok', aabb);
+      return true;
+    }
+
+    // Expose un adaptateur global unique
+    window.viewerAdapter = { viewer, loadFromFileId };
+    console.log('[viewer] init ok');
+    return viewer;
+  };
+
+  // Démarrage automatique après DOM si personne n'appelle initViewer explicitement
+  document.addEventListener('DOMContentLoaded', () => {
+    if (!window.viewerAdapter) {
+      const canvas = document.getElementById('xktCanvas');
+      if (canvas) window.initViewer({ canvasElement: canvas });
+    }
+  });
+}
+// PATCH END
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -190,9 +190,8 @@
 
     <!-- === CONTENEUR VIEWER NOUVEAU (overlay) === -->
     <div id="viewer" class="viewer-wrapper position-relative" style="height: 600px; border-radius:10px; background:#e8e9ea; overflow:hidden;">
-      <!-- PATCH START: viewer canvas -->
+      <!-- PATCH: viewer canvas -->
       <canvas id="xktCanvas" class="xkt-canvas" aria-label="3D viewer"></canvas>
-      <!-- PATCH END -->
 
       <!-- Barre d’outils overlay : IDs attendus par main.js -->
       <div id="toolbar" data-viewer-required class="toolbar position-absolute" style="top:10px; left:10px; z-index:10; display:flex; gap:8px;">
@@ -204,9 +203,6 @@
         <button id="resetBtn"   class="btn btn-sm btn-light"  title="Réinitialiser (R)">Reset</button>
         <button id="pngBtn"     class="btn btn-sm btn-light"  title="Exporter PNG">PNG</button>
       </div>
-
-      <canvas id="axisGizmo" class="position-absolute" width="80" height="80" style="bottom:10px; right:10px; z-index:10;">
-      </canvas>
 
       <!-- Panneau latéral compact (mesures + coupes) exploité par main.js -->
       <aside id="sidePanel" class="panel collapsed position-absolute"


### PR DESCRIPTION
## Summary
- alias Xeokit v2 imports to avoid redeclaration
- initialize viewer once with default canvas fallback and global adapter
- ensure 3D viewer template uses a single `xktCanvas`
- trigger model conversion and viewer loading via global `viewerAdapter`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run smoke:dfm` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c7b03181808333a1eb8009daf6b288