### PR TITLE
Allow HEAD requests for model files

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -211,7 +211,7 @@ def job_result(job_id: str):
         return {"error": "Result not ready"}, 404
     return result
 
-@app.route("/models/<path:filename>")
+@app.route("/models/<path:filename>", methods=["GET", "HEAD"])
 def models(filename):
     mimetype = None
     if filename.endswith(".xkt"):


### PR DESCRIPTION
## Summary
- support GET and HEAD on `/models/<path:filename>`

## Testing
- `pytest -q` (fails: ModuleNotFoundError: No module named 'flask')
- `python app/app.py` (fails: redis/queue import error)


------
https://chatgpt.com/codex/tasks/task_e_68c7bd418d588333b06edfac0fac8bd9