### PR TITLE
Fix viewer init timing and camera fitting

### DIFF
--- a/static/js/modules/viewer.js
+++ b/static/js/modules/viewer.js
@@ -79,7 +79,11 @@ if (!window.__XE_VIEWER_BOOT__) {
   window.initViewer = function initViewer(cfg = {}) {
     const canvas = getCanvasFromConfig(cfg);
     if (!canvas) {
-      console.error('[viewer] canvas introuvable', { cfg });
+      if (document.readyState === "loading") {
+        document.addEventListener("DOMContentLoaded", () => initViewer(cfg), { once: true });
+      } else {
+        console.error('[viewer] canvas introuvable', { cfg });
+      }
       return null;
     }
     const viewer = new XEViewer({ canvasElement: canvas });
@@ -109,7 +113,7 @@ if (!window.__XE_VIEWER_BOOT__) {
       const model = await xktLoader.load({ src: url });
       console.timeEnd('[viewer] xkt load');
       const aabb = (model && model.aabb) || viewer.scene.aabb;
-      if (aabb) viewer.cameraControl.fit(aabb);
+      if (aabb) viewer.cameraFlight.fit(aabb);
       console.log('[viewer] fit ok', aabb);
       return true;
     }


### PR DESCRIPTION
## Summary
- Retry initViewer on DOMContentLoaded when canvas is missing during loading
- Use cameraFlight for fitting scene bounds

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c7c649a9a48333a6de9696134ed9ec