### PR TITLE
Cache panneau axe et ajuste viewer

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1439,3 +1439,11 @@ body {
 #dfmAxisPanel,#axis-panel{display:none;} /* anti-flash: axe caché au chargement */
 /* PATCH END */
 
+#dfmAxisPanel {
+  display: none;
+}
+
+.viewer-wrapper {
+  min-height: 420px;
+}
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -189,7 +189,7 @@
     </div>
 
     <!-- === CONTENEUR VIEWER NOUVEAU (overlay) === -->
-    <div id="viewer" class="viewer-wrapper position-relative" style="height: 600px; border-radius:10px; background:#e8e9ea; overflow:hidden;">
+    <div id="viewer" class="viewer-wrapper position-relative" style="height: 100%; border-radius:10px; background:#e8e9ea; overflow:hidden;">
       <!-- PATCH: viewer canvas -->
       <canvas id="xktCanvas" class="xkt-canvas" aria-label="3D viewer"></canvas>
 


### PR DESCRIPTION
## Summary
- Masque définitivement le panneau de sélection d'axe
- Donne une hauteur minimale au conteneur du viewer
- Corrige la hauteur inline du viewer pour occuper toute la hauteur disponible

## Testing
- `pytest` *(échoue: ModuleNotFoundError: No module named 'PIL', AttributeError: 'types.SimpleNamespace' object has no attribute 'Workplane', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c7c79183cc83338778690d7e683719