### PR TITLE
Use xkt_converter for STEP conversion in API

### DIFF
--- a/app/api/contract_routes.py
+++ b/app/api/contract_routes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import os
-import subprocess
 import uuid
 from datetime import datetime
 from typing import Any
@@ -11,6 +10,7 @@ from werkzeug.utils import secure_filename
 
 from app.storage.storage import Storage
 from app.storage import history as History
+import xkt_converter
 
 UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
 OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
@@ -94,22 +94,19 @@ def convert_step() -> tuple[Any, int]:
                 )
             return jsonify({"file_id": file_id, "xkt_url": f"/models/{file_id}.xkt"}), 200
 
-        xeokit_bin_path = os.environ.get("XEOKIT_CONVERT") or "xeokit-convert"
+        try:
+            xkt_converter.convert_step_to_xkt(
+                step_in_path,
+                xkt_out_path,
+                stl_tolerance=float(data.get("tolerance", 0.1)),
+            )
+        except Exception as exc:
+            current_app.logger.error("[convert] failed %s", exc)
+            return jsonify({"error": "convert_failed"}), 500
 
-        # PATCH START: resilient xeokit convert
-        def _run(cmd):
-            return subprocess.run(cmd, capture_output=True, text=True, timeout=300)
-
-        tried = []
-        for variant in (["--output", xkt_out_path], ["-o", xkt_out_path], ["--out", xkt_out_path]):
-            cmd = [xeokit_bin_path, *variant, step_in_path]
-            tried.append(" ".join(cmd))
-            res = _run(cmd)
-            if res.returncode == 0:
-                break
-        else:
-            current_app.logger.error(f"[convert] failed tried={tried} stderr={res.stderr[:2000]}")
-            return jsonify({"error":"convert_failed","stderr":res.stderr}), 500
+        if not os.path.exists(xkt_out_path):
+            current_app.logger.error("[convert] output missing %s", xkt_out_path)
+            return jsonify({"error": "convert_failed"}), 500
 
         current_app.logger.info(
             f"[convert] XKT ready /models/{file_id}.xkt"
@@ -124,7 +121,6 @@ def convert_step() -> tuple[Any, int]:
                 "history convert failed for %s: %s", file_id, exc
             )
         return jsonify({"file_id": file_id, "xkt_url": f"/models/{file_id}.xkt"}), 200
-        # PATCH END
     except Exception as exc:  # pragma: no cover
         current_app.logger.error("[convert] unexpected error: %s", exc)
         return jsonify({"error": "convert_failed", "message": str(exc)}), 500

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -1,15 +1,17 @@
 from pathlib import Path
-import subprocess
 import os
+import sys
+import types
 
 import pytest
 from flask import Flask
 
-from app.api.contract_routes import api_contract_bp
-
 
 @pytest.fixture
-def client():
+def client(monkeypatch):
+    fake_module = types.SimpleNamespace(convert_step_to_xkt=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "xkt_converter", fake_module)
+    from app.api.contract_routes import api_contract_bp
     app = Flask(__name__)
     app.register_blueprint(api_contract_bp)
     app.config["TESTING"] = True
@@ -37,11 +39,13 @@ def test_upload_convert_analyze_flow(client, monkeypatch):
     assert entry["filename"].endswith(SAMPLE_STEP.name)
     assert "xkt_ready" not in entry
 
-    def fake_run(cmd, capture_output, text, timeout):
-        Path(cmd[2]).write_bytes(b"x")
-        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+    def fake_convert(inp, out, stl_tolerance):
+        Path(out).write_bytes(b"x")
 
-    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.api.contract_routes.xkt_converter.convert_step_to_xkt",
+        fake_convert,
+    )
 
     resp = client.post("/api/simple/convert", json={"file_id": file_id})
     assert resp.status_code == 200
@@ -104,17 +108,22 @@ def test_convert_idempotent(client, monkeypatch):
         resp = client.post("/api/simple/upload", data={"file": fh})
     file_id = resp.get_json()["file_id"]
 
-    def fake_run(cmd, capture_output, text, timeout):
-        Path(cmd[2]).write_bytes(b"x")
-        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+    def fake_convert(inp, out, stl_tolerance):
+        Path(out).write_bytes(b"x")
 
-    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.api.contract_routes.xkt_converter.convert_step_to_xkt",
+        fake_convert,
+    )
     client.post("/api/simple/convert", json={"file_id": file_id})
 
-    def fail_run(*args, **kwargs):  # should not be called
+    def fail_convert(*args, **kwargs):  # should not be called
         raise AssertionError("should not run")
 
-    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fail_run)
+    monkeypatch.setattr(
+        "app.api.contract_routes.xkt_converter.convert_step_to_xkt",
+        fail_convert,
+    )
     resp = client.post("/api/simple/convert", json={"file_id": file_id})
     assert resp.status_code == 200
 
@@ -124,16 +133,18 @@ def test_convert_failure_returns_500(client, monkeypatch):
         resp = client.post("/api/simple/upload", data={"file": fh})
     file_id = resp.get_json()["file_id"]
 
-    def fail_run(cmd, capture_output, text, timeout):
-        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="boom error")
+    def fail_convert(inp, out, stl_tolerance):
+        pass  # do not create file
 
-    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fail_run)
+    monkeypatch.setattr(
+        "app.api.contract_routes.xkt_converter.convert_step_to_xkt",
+        fail_convert,
+    )
 
     resp = client.post("/api/simple/convert", json={"file_id": file_id})
     assert resp.status_code == 500
     body = resp.get_json()
     assert body["error"] == "convert_failed"
-    assert "boom" in body["stderr"]
 
 
 def test_models_route_serves_xkt(client):

--- a/tests/test_dfm_smoke.py
+++ b/tests/test_dfm_smoke.py
@@ -6,8 +6,6 @@ import sys
 
 from flask import Flask
 
-from api.contract import api_contract_bp
-
 
 def test_dfm_smoke(tmp_path, monkeypatch):
     uploads = tmp_path / "uploads"
@@ -17,6 +15,10 @@ def test_dfm_smoke(tmp_path, monkeypatch):
     monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
     monkeypatch.setenv("OUTPUT_FOLDER", str(outputs))
     monkeypatch.setenv("FILES_DB_PATH", str(tmp_path / "files.sqlite"))
+
+    fake_module = types.SimpleNamespace(convert_step_to_xkt=lambda *a, **k: None)
+    monkeypatch.setitem(sys.modules, "xkt_converter", fake_module)
+    from api.contract import api_contract_bp
 
     # Stub Celery task module before importing routes
     report_template = {
@@ -43,8 +45,14 @@ def test_dfm_smoke(tmp_path, monkeypatch):
         (out_dir / "report.json").write_text(json.dumps(report_template))
         return types.SimpleNamespace(id="job1")
 
+    fake_tasks = types.ModuleType("tasks.dfm")
+    fake_tasks.dfm_run = types.SimpleNamespace(delay=stub_delay)
+    monkeypatch.setitem(sys.modules, "tasks.dfm", fake_tasks)
+    fake_mat = types.ModuleType("app.material_profiles")
+    fake_mat.get_profile = lambda name: {"id": name}
+    monkeypatch.setitem(sys.modules, "app.material_profiles", fake_mat)
+
     import app.api.dfm_routes as routes
-    monkeypatch.setattr(routes.dfm_run, "delay", stub_delay)
 
     app = Flask(__name__)
     app.register_blueprint(api_contract_bp)
@@ -52,11 +60,13 @@ def test_dfm_smoke(tmp_path, monkeypatch):
     client = app.test_client()
 
     # stub converter
-    def fake_run(cmd, capture_output, text, timeout):
-        Path(cmd[3]).write_text("xkt")
-        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+    def fake_convert(inp, out, stl_tolerance):
+        Path(out).write_text("xkt")
 
-    monkeypatch.setattr("app.api.contract_routes.subprocess.run", fake_run)
+    monkeypatch.setattr(
+        "app.api.contract_routes.xkt_converter.convert_step_to_xkt",
+        fake_convert,
+    )
     gen_mod = types.ModuleType("generate_thumbnails")
     gen_mod.generate_thumbnails = lambda step_path, out_dir: {"iso": str(Path(out_dir) / "preview.png")}
     sys.modules["generate_thumbnails"] = gen_mod


### PR DESCRIPTION
## Summary
- Replace subprocess-based STEP→XKT conversion with `xkt_converter.convert_step_to_xkt`
- Fail gracefully if converter output is missing
- Update contract API tests to stub converter
- Adjust DFM smoke test to stub Celery/material profile modules

## Testing
- `pytest tests/test_api_contract.py tests/test_dfm_smoke.py`

------
https://chatgpt.com/codex/tasks/task_e_68c7cd1b93e48333b98bcb5cbc285022