### PR TITLE
feat: handle upload and visualization

### DIFF
--- a/static/js/DFMOrchestrator.js
+++ b/static/js/DFMOrchestrator.js
@@ -17,7 +17,7 @@ if (typeof window !== "undefined") {
 }
 
 // PATCH START: selectors
-// const btnVisualiser = document.querySelector('#btn-visualiser, #visualizeBtn');
+// const btnVisualiser = document.querySelector('#btnVisualiser');
 const btnAnalyser   = document.querySelector('#analyzeBtn, #btn-analyser');
 const axisPanel     = document.querySelector('#dfmAxisPanel, #axis-panel');
 // PATCH END
@@ -865,7 +865,7 @@ if (typeof window !== 'undefined') {
 
 // --- Visualiser & analyse workflow ---------------------------------------
 function getTolerance() {
-  const v = parseFloat(document.getElementById("toleranceInput")?.value);
+  const v = parseFloat(document.getElementById("toleranceSelect")?.value);
   return Number.isFinite(v) ? v : 0.1;
 }
 
@@ -874,7 +874,7 @@ if (typeof window !== "undefined") window.getTolerance = getTolerance;
 // PATCH START: visualize flow via viewerAdapter
 (function(){
   function $(s){ return document.querySelector(s); }
-  const btnVisualiser = $('#btn-visualiser, #visualizeBtn');
+  const btnVisualiser = $('#btnVisualiser');
 
   async function doVisualize(fid){
     if (!fid) { console.warn('[visualiser] no fileId'); return; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,32 +1,115 @@
 // static/js/main.js
-import { startViewer } from './viewer.js';
+import { startViewer, loadXKT } from './viewer.js';
 
-export function attachViewerHandlers() {
-  const bind = () => {
-    const btn = document.querySelector('#btn-visualiser, #visualizeBtn');
-    if (!btn) return;
-    btn.addEventListener('click', async (e) => {
-      e.preventDefault();
-      console.info('[viewer] visualize click');
-      const fid = window.currentFileId;
-      if (fid && window.viewerAdapter?.loadFromFileId) {
-        try {
-          await window.viewerAdapter.loadFromFileId(fid);
-          console.info('[viewer] XKT loaded', fid);
-        } catch (err) {
-          console.error('[viewer] load failed', err);
-        }
-      } else {
-        console.warn('[viewer] no XKT disponible');
-      }
-    });
-  };
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', bind, { once: true });
+const state = {
+  file: null,
+  file_id: null,
+  aborter: null,
+};
+
+function setBtnState(text, loading = false) {
+  const btn = document.getElementById('btnVisualiser');
+  if (!btn) return;
+  btn.disabled = loading;
+  if (loading) {
+    btn.innerHTML = `<span class="spinner-border spinner-border-sm me-2" role="status"></span>${text}`;
   } else {
-    bind();
+    btn.textContent = text;
   }
 }
 
-startViewer();
-attachViewerHandlers();
+function attachUploadHandlers() {
+  const fileInput = document.getElementById('fileInput');
+  const btn = document.getElementById('btnVisualiser');
+  const tolerance = document.getElementById('toleranceSelect');
+  if (!fileInput || !btn) {
+    console.error('[ui] fileInput ou btnVisualiser introuvable');
+    return;
+  }
+  fileInput.addEventListener('change', (e) => {
+    state.file = e.target.files?.[0] || null;
+    console.info('[upload] fichier sélectionné:', state.file?.name);
+  });
+  btn.addEventListener('click', (e) => {
+    e.preventDefault();
+    if (!state.file) {
+      alert('Sélectionne un fichier STEP/STP avant de visualiser.');
+      return;
+    }
+    const tol = tolerance?.value || 'standard';
+    uploadAndConvert(state.file, tol);
+  });
+}
+
+async function uploadAndConvert(file, tolerance) {
+  console.info('[upload] démarrage', { name: file.name, tolerance });
+  const fd = new FormData();
+  fd.append('file', file);
+  fd.append('tolerance', tolerance);
+  setBtnState('Envoi…', true);
+  try {
+    // Route canonique côté Flask (à adapter si nécessaire)
+    const res = await fetch('/upload', { method: 'POST', body: fd });
+    if (!res.ok) throw new Error('Upload failed ' + res.status);
+    const data = await res.json();
+    console.info('[upload] réponse', data);
+    const { file_id, xkt_url } = data;
+    state.file_id = file_id;
+    if (xkt_url) {
+      setBtnState('Affichage…', true);
+      await loadXKT(xkt_url);
+      setBtnState('Prêt');
+      return;
+    }
+    setBtnState('Conversion…', true);
+    await pollStatus(file_id);
+    setBtnState('Prêt');
+  } catch (err) {
+    console.error('[upload] erreur', err);
+    alert("Erreur réseau ou serveur lors de l'upload ou de la conversion.");
+    setBtnState('Prêt');
+  }
+}
+
+async function pollStatus(file_id) {
+  console.info('[convert] polling', { file_id });
+  state.aborter?.abort();
+  const ac = new AbortController();
+  state.aborter = ac;
+  let tries = 0;
+  const maxTries = 80; // ~2 minutes à 1.5s
+  async function tick() {
+    tries++;
+    let r;
+    try {
+      r = await fetch(`/convert/status?file_id=${encodeURIComponent(file_id)}`, { signal: ac.signal });
+    } catch (e) {
+      throw new Error('network');
+    }
+    if (!r.ok) throw new Error('status http ' + r.status);
+    const j = await r.json();
+    console.info('[convert] statut', j);
+    if (j.status === 'ready' && j.xkt_url) {
+      setBtnState('Affichage…', true);
+      await loadXKT(j.xkt_url);
+      console.info('[viewer] XKT chargé');
+      return;
+    }
+    if (j.status === 'failed') {
+      throw new Error('conversion failed');
+    }
+    if (tries < maxTries) {
+      setTimeout(tick, 1500);
+    } else {
+      throw new Error('timeout conversion');
+    }
+  }
+  return tick();
+}
+
+// bootstrap
+(async () => {
+  await startViewer();          // démarre le canvas et le smoke test
+  attachUploadHandlers();       // connecte l’UI d’upload
+})();
+

--- a/static/js/viewer.js
+++ b/static/js/viewer.js
@@ -1,5 +1,7 @@
 // static/js/viewer.js
 
+let _viewer, _xktLoader;
+
 export async function loadCameraPresetOptional(u) {
   try {
     const r = await fetch(u, { cache: 'no-store' });
@@ -58,15 +60,41 @@ function smokeTestGL(canvas) {
 }
 
 export async function startViewer() {
-  if (window.__viewerBooted) {
+  if (_viewer) {
     console.warn('[viewer] déjà initialisé');
-    return window.__viewerInstance;
+    return { canvas: _viewer.canvas }; // retourne au moins le canvas
   }
   const { canvas } = await initViewer();
   smokeTestGL(canvas);
-  const instance = { canvas /*, viewer */ };
-  window.__viewerBooted = true;
-  window.__viewerInstance = instance;
+  if (window.__CADLYTICS_VIEWER) {
+    _viewer = window.__CADLYTICS_VIEWER;
+    _xktLoader = window.__CADLYTICS_XKT_LOADER || _xktLoader;
+  } else {
+    const mod = await import('https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk@2/dist/xeokit-sdk.es.js');
+    const { Viewer, XKTLoaderPlugin } = mod;
+    _viewer = new Viewer({ canvasId: canvas.id });
+    _xktLoader = new XKTLoaderPlugin(_viewer);
+    window.__CADLYTICS_VIEWER = _viewer;
+    window.__CADLYTICS_XKT_LOADER = _xktLoader;
+  }
   console.info('[viewer] ready (sans modèle)');
-  return instance;
+  return { canvas };
+}
+
+export async function loadXKT(url) {
+  console.info('[viewer] loadXKT', url);
+  if (!_viewer) throw new Error('viewer non initialisé');
+  let model;
+  if (_xktLoader && _xktLoader.load) {
+    model = await _xktLoader.load({ id: 'model', src: url, edges: true });
+    const aabb = model?.aabb || _viewer.scene?.aabb;
+    if (aabb && _viewer.cameraFlight) {
+      _viewer.cameraFlight.fit(aabb);
+    }
+  } else if (_viewer.loadXKT) {
+    model = await _viewer.loadXKT(url);
+    if (_viewer.fitAll) _viewer.fitAll();
+  }
+  console.info('[viewer] XKT affiché');
+  return model;
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -117,10 +117,10 @@
                         
                         <!-- Contrôles de tolérance -->
                         <div class="mt-3">
-                            <label for="toleranceInput" class="form-label" style="color: var(--brown-dark); font-weight: 600;">
+                            <label for="toleranceSelect" class="form-label" style="color: var(--brown-dark); font-weight: 600;">
                                 {{ t.upload_tolerance }}
                             </label>
-                            <select class="form-select" id="toleranceInput" name="tolerance">
+                            <select class="form-select" id="toleranceSelect" name="tolerance">
                                 <option value="0.01">{{ t.upload_high_precision }}</option>
                                 <option value="0.1" selected>{{ t.upload_standard }}</option>
                                 <option value="0.5">{{ t.upload_fast }}</option>
@@ -133,7 +133,7 @@
                         
                         <!-- Bouton principal -->
                         <div class="text-center mt-4">
-                            <button type="button" class="btn btn-primary btn-lg" id="visualizeBtn">
+                            <button type="button" class="btn btn-primary btn-lg" id="btnVisualiser">
                                 <i class="bi bi-eye me-2"></i>
                                 {{ t.upload_visualize }}
                             </button>

--- a/tests/test_viewer_upload.py
+++ b/tests/test_viewer_upload.py
@@ -1,0 +1,55 @@
+import io
+import os
+import types
+import sys
+
+os.environ.setdefault('SESSION_SECRET', 'test-secret')
+os.environ.setdefault('DATABASE_URL', 'sqlite://')
+
+sys.modules['cadquery'] = types.SimpleNamespace(
+    importers=types.SimpleNamespace(importStep=lambda *a, **k: None),
+    exporters=types.SimpleNamespace(export=lambda *a, **k: None),
+)
+sys.modules['trimesh'] = types.SimpleNamespace(load=lambda *a, **k: types.SimpleNamespace(is_empty=False, faces=[1]))
+sys.modules['xkt_converter'] = types.SimpleNamespace(convert_step_to_xkt=lambda *a, **k: None)
+ocp = types.SimpleNamespace(
+    STEPControl=types.SimpleNamespace(STEPControl_Reader=object),
+    StlAPI=types.SimpleNamespace(StlAPI_Writer=object),
+    Interface=types.SimpleNamespace(Interface_Static=object),
+)
+sys.modules['OCP'] = ocp
+sys.modules['OCP.STEPControl'] = ocp.STEPControl
+sys.modules['OCP.StlAPI'] = ocp.StlAPI
+sys.modules['OCP.Interface'] = ocp.Interface
+
+from web import app
+import web
+
+
+def test_upload_and_status(tmp_path, monkeypatch):
+    upload_dir = tmp_path / 'uploads'
+    output_dir = tmp_path / 'converted'
+    upload_dir.mkdir()
+    output_dir.mkdir()
+    monkeypatch.setattr(web, 'UPLOAD_FOLDER', str(upload_dir))
+    monkeypatch.setattr(web, 'OUTPUT_FOLDER', str(output_dir))
+
+    def fake_convert(step_path, xkt_path, tolerance):
+        with open(xkt_path, 'wb') as f:
+            f.write(b'xkt')
+    monkeypatch.setattr(web, 'run_sync_conversion', fake_convert)
+
+    client = app.test_client()
+    data = {'file': (io.BytesIO(b'data'), 'sample.step')}
+    resp = client.post('/upload', data=data)
+    assert resp.status_code == 200
+    js = resp.get_json()
+    assert js['status'] == 'ready'
+    fid = js['file_id']
+    assert (output_dir / f"{fid}.xkt").exists()
+
+    resp2 = client.get(f'/convert/status?file_id={fid}')
+    assert resp2.status_code == 200
+    js2 = resp2.get_json()
+    assert js2['status'] == 'ready'
+    assert js2['xkt_url'].endswith(f'{fid}.xkt')

--- a/web.py
+++ b/web.py
@@ -150,6 +150,59 @@ def __routes():
 # ========= FIN PATCH =========
 
 
+ALLOWED = {'.stp', '.step'}
+
+
+def allowed(filename: str) -> bool:
+    ext = os.path.splitext(filename.lower())[1]
+    return ext in ALLOWED
+
+
+@app.post('/upload')
+def upload():
+    f = request.files.get('file')
+    tol = request.form.get('tolerance', 'standard')
+    if not f or not f.filename:
+        return jsonify(error='no_file'), 400
+    if not allowed(f.filename):
+        return jsonify(error='bad_ext'), 400
+    file_id = str(uuid.uuid4())
+    step_path = os.path.join(UPLOAD_FOLDER, f'{file_id}.step')
+    f.save(step_path)
+    xkt_path = os.path.join(OUTPUT_FOLDER, f'{file_id}.xkt')
+    try:
+        run_sync_conversion(step_path, xkt_path, tol)
+        status = 'ready' if os.path.exists(xkt_path) else 'processing'
+    except Exception as e:
+        return jsonify(error='convert_fail', detail=str(e)), 500
+    xkt_url = f'/xkt/{file_id}.xkt' if os.path.exists(xkt_path) else None
+    return jsonify(file_id=file_id, status=status, xkt_url=xkt_url)
+
+
+@app.get('/convert/status')
+def convert_status():
+    file_id = request.args.get('file_id')
+    if not file_id:
+        return jsonify(error='no_file_id'), 400
+    xkt_path = os.path.join(OUTPUT_FOLDER, f'{file_id}.xkt')
+    if os.path.exists(xkt_path):
+        return jsonify(status='ready', xkt_url=f'/xkt/{file_id}.xkt')
+    return jsonify(status='processing')
+
+
+@app.get('/xkt/<path:fname>')
+def serve_xkt(fname: str):
+    if not fname.endswith('.xkt'):
+        abort(404)
+    return send_from_directory(OUTPUT_FOLDER, fname, as_attachment=False)
+
+
+def run_sync_conversion(step_path: str, xkt_path: str, tolerance: str):
+    tol_map = {'coarse': 1.0, 'fine': 0.2}
+    stl_tol = tol_map.get(tolerance, 0.6)
+    xkt_converter.convert_step_to_xkt(step_path, xkt_path, stl_tolerance=stl_tol)
+
+
 def _resolve_xeokit():
     """Résout le binaire xeokit-convert ou renvoie 'npx'."""
     xeokit = os.getenv("XEOKIT_CONVERT") or shutil.which("xeokit-convert")
@@ -712,8 +765,8 @@ def upload_file_api():
     return jsonify({'file_id': file_id})
 
 
-@app.route('/upload', methods=['POST'])
-def upload():
+@app.route('/upload_legacy', methods=['POST'])
+def upload_legacy():
     """Upload a STEP/STP file then ouvrir le viewer intégré"""
     if 'file' not in request.files:
         flash('Aucun fichier sélectionné', 'error')


### PR DESCRIPTION
## Summary
- harmonize IDs in 3D analysis template
- add upload & convert flow with polling in main.js
- extend viewer to load XKT models and auto-fit camera
- expose `/upload` and `/convert/status` endpoints serving XKT files
- add smoke test for upload/convert flow
- show spinner and text states on visualize button
- handle network errors during upload & conversion

## Testing
- `npm run build`
- `pytest tests/test_viewer_upload.py -q` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68c7eb2d5ff88333a4f246afd7714078