### PR TITLE
Use robust npx for xeokit conversion and hide viewer tools

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1453,14 +1453,14 @@ body {
   box-shadow: 0 0 0 4px rgba(63,179,93,.15);
 }
 
-.viewer-tools {
-  opacity: .25;
-  pointer-events: none;
-  transition: opacity .2s ease;
-}
-
-.has-model .viewer-tools {
-  opacity: 1;
-  pointer-events: auto;
+/* Masquer panneaux viewer inutiles */
+.viewer-tools,
+.viewerToolsPanel,
+.viewer-tools-panel,
+#viewerToolsPanel,
+#viewer-tools-panel,
+.viewer-side-tools,
+#viewerSideTools {
+  display: none !important;
 }
 

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -22,27 +22,38 @@ async function uploadAndConvert(btn) {
   fd.append('tolerance', tol);
 
   setBtn(btn, 'Envoi…', true, true);
-  const r = await fetch('/upload', { method: 'POST', body: fd });
-  const j = await r.json().catch(() => ({}));
-  console.info('[upload] /upload →', j);
-  if (!r.ok) throw new Error(j?.error || ('HTTP ' + r.status));
-  state.file_id = j.file_id;
+  try {
+    const r = await fetch('/upload', { method: 'POST', body: fd });
+    const j = await r.json().catch(() => ({}));
+    console.info('[upload] /upload →', j);
+    if (!r.ok) {
+      const msg = j?.detail || j?.error || ('HTTP ' + r.status);
+      throw new Error(msg);
+    }
+    state.file_id = j.file_id;
 
-  if (j.xkt_url) {
-    setBtn(btn, 'Affichage…', true, true);
-    await loadXKT(j.xkt_url);
-    setBtn(btn, 'Prêt', false, false);
-    markDropSuccess(true);
-    return;
+    if (j.xkt_url) {
+      setBtn(btn, 'Affichage…', true, true);
+      await loadXKT(j.xkt_url);
+      setBtn(btn, 'Prêt', false, false);
+      markDropSuccess(true);
+      return;
+    }
+
+    setBtn(btn, 'Conversion…', true, true);
+    await pollStatus(state.file_id, async (xkt_url) => {
+      setBtn(btn, 'Affichage…', true, true);
+      await loadXKT(xkt_url);
+      setBtn(btn, 'Prêt', false, false);
+      markDropSuccess(true);
+    });
+  } catch (err) {
+    console.error('[upload] erreur', err);
+    alert('Erreur upload/convert : ' + (err?.message || err));
+    markDropSuccess(false);
+    setBtn(btn, 'VISUALISER', false, false);
+    return; // stop flow
   }
-
-  setBtn(btn, 'Conversion…', true, true);
-  await pollStatus(state.file_id, async (xkt_url) => {
-    setBtn(btn, 'Affichage…', true, true);
-    await loadXKT(xkt_url);
-    setBtn(btn, 'Prêt', false, false);
-    markDropSuccess(true);
-  });
 }
 
 function markDropSuccess(ok) {
@@ -82,16 +93,14 @@ function attachUploadHandlers() {
     markDropSuccess(false);
     // auto-lancement dès sélection
     if (state.file) {
-      try { await uploadAndConvert(btn); }
-      catch (err) { console.error(err); alert('Upload/convert erreur: ' + err.message); markDropSuccess(false); setBtn(btn, 'VISUALISER', false, false); }
+      await uploadAndConvert(btn);
     }
   });
 
   btn.addEventListener('click', async (e) => {
     e.preventDefault();
     if (!state.file) { alert('Choisis un fichier .stp/.step'); return; }
-    try { await uploadAndConvert(btn); }
-    catch (err) { console.error(err); alert('Upload/convert erreur: ' + err.message); markDropSuccess(false); setBtn(btn, 'VISUALISER', false, false); }
+    await uploadAndConvert(btn);
   });
 }
 

--- a/web.py
+++ b/web.py
@@ -27,6 +27,7 @@ import time
 import shutil
 import tempfile
 import subprocess
+import shlex
 from OCP.STEPControl import STEPControl_Reader
 from OCP.StlAPI import StlAPI_Writer
 from OCP.Interface import Interface_Static
@@ -171,7 +172,7 @@ def upload():
     xkt = os.path.join(OUTPUT_FOLDER, f'{file_id}.xkt')
     f.save(step)
     try:
-        run_sync_conversion(step, xkt, tol)
+        run_xkt_convert(step, xkt, tol)
     except Exception as e:
         return jsonify(error='convert_fail', detail=str(e)), 500
     xkt_url = f'/xkt/{file_id}.xkt' if os.path.exists(xkt) else None
@@ -188,7 +189,6 @@ def convert_status():
         return jsonify(status='ready', xkt_url=f'/xkt/{file_id}.xkt')
     return jsonify(status='processing')
 
-
 @app.get('/xkt/<path:fname>')
 def serve_xkt(fname: str):
     if not fname.endswith('.xkt'):
@@ -196,9 +196,31 @@ def serve_xkt(fname: str):
     return send_from_directory(OUTPUT_FOLDER, fname, as_attachment=False)
 
 
-def run_sync_conversion(step_path: str, xkt_path: str, tolerance: str):
-    cmd = ['xeokit-convert', '--input', step_path, '--output', xkt_path]
-    subprocess.run(cmd, check=True)
+def _npx_cmd():
+    candidates = [
+        "npx",
+        "/opt/render/project/nodes/node-20.19.5/bin/npx",
+        "/opt/render/project/nodes/node-*/bin/npx"
+    ]
+    for c in candidates:
+        if os.path.exists(c) or c == "npx":
+            return c
+    return "npx"
+
+
+def run_xkt_convert(step_path: str, xkt_path: str, tolerance: str = "standard"):
+    npx = _npx_cmd()
+    cmd = f"""{shlex.quote(npx)} -y @xeokit/xeokit-convert@latest \
+      --input {shlex.quote(step_path)} \
+      --output {shlex.quote(xkt_path)}"""
+    env = os.environ.copy()
+    env["PATH"] = env.get("PATH", "") + ":/opt/render/project/nodes/node-20.19.5/bin"
+    proc = subprocess.run(cmd, shell=True, env=env,
+                          stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"xeokit-convert failed ({proc.returncode})\nSTDOUT:\n{proc.stdout}\nSTDERR:\n{proc.stderr}"
+        )
 
 
 def _resolve_xeokit():


### PR DESCRIPTION
## Summary
- run xeokit conversion through `npx -y @xeokit/xeokit-convert@latest`
- capture stdout/stderr and surface errors to client
- display conversion errors in UI using backend details
- hide unused viewer tool panels via global CSS

## Testing
- `npm run build`
- `pip install -r requirements.txt` *(fails: InvalidVersion: 'x86_64')*
- `pytest` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68c808f9fa188333ba6ce60ecafd4f69