### PR TITLE
Évite les imports lourds côté web et ajuste Render

### DIFF
--- a/.replit
+++ b/.replit
@@ -7,7 +7,7 @@ packages = ["cacert", "cairo", "cargo", "cgal_5", "chromedriver", "expat", "ffmp
 [deployment]
 deploymentTarget = "autoscale"
 run = ["gunicorn", "--bind", "0.0.0.0:5000", "main:app"]
-build = ["sh", "-c", "pip install -r requirements.txt"]
+build = ["sh", "-c", "pip install -r requirements-web.txt"]
 
 [workflows]
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,3 +1,6 @@
+from typing import Any, Tuple
+
+
 try:
     from .app import app  # type: ignore
 except Exception:  # pragma: no cover
@@ -33,13 +36,35 @@ except Exception:  # pragma: no cover
     except Exception:  # pragma: no cover
         pass  # keep shim
 
-try:
-    from tasks.conversion import generate_preview, generate_final
-except Exception:  # pragma: no cover
-    def generate_preview(*args, **kwargs):
-        raise RuntimeError("generate_preview not available")
-    def generate_final(*args, **kwargs):
-        raise RuntimeError("generate_final not available")
+def _send_task(task_name: str, args: Tuple[Any, ...] | list[Any], kwargs: dict, options: dict | None = None):
+    """Envoie une tâche Celery sans importer les modules lourds."""
+    from celery_app import celery
+
+    options = options or {}
+    if not isinstance(args, tuple):
+        args = tuple(args)
+    return celery.send_task(task_name, args=args, kwargs=kwargs, **options)
+
+
+class _CeleryTaskProxy:
+    """Proxy léger exposant les tâches Celery sans import CadQuery/Trimesh."""
+
+    def __init__(self, task_name: str):
+        self.task_name = task_name
+        self.name = task_name
+
+    def __call__(self, *args: Any, **kwargs: Any):
+        return self.delay(*args, **kwargs)
+
+    def delay(self, *args: Any, **kwargs: Any):
+        return _send_task(self.task_name, args, kwargs)
+
+    def apply_async(self, args: Tuple[Any, ...] | None = None, kwargs: dict | None = None, **options: Any):
+        return _send_task(self.task_name, args or (), kwargs or {}, options)
+
+
+generate_preview = _CeleryTaskProxy("tasks.generate_preview")
+generate_final = _CeleryTaskProxy("tasks.generate_final")
 # >>> CADLYTICS PATCH: EXPORTS (END)
 
 __all__ = ["app", "db", "generate_preview", "generate_final"]

--- a/app/api/contract_routes.py
+++ b/app/api/contract_routes.py
@@ -10,7 +10,14 @@ from werkzeug.utils import secure_filename
 
 from app.storage.storage import Storage
 from app.storage import history as History
-import xkt_converter
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _convert_step_to_xkt():
+    from xkt_converter import convert_step_to_xkt
+
+    return convert_step_to_xkt
 
 UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
 OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
@@ -95,7 +102,8 @@ def convert_step() -> tuple[Any, int]:
             return jsonify({"file_id": file_id, "xkt_url": f"/models/{file_id}.xkt"}), 200
 
         try:
-            xkt_converter.convert_step_to_xkt(
+            convert = _convert_step_to_xkt()
+            convert(
                 step_in_path,
                 xkt_out_path,
                 stl_tolerance=float(data.get("tolerance", 0.1)),

--- a/app/converters/mesh_simplify.py
+++ b/app/converters/mesh_simplify.py
@@ -1,6 +1,12 @@
 """Mesh simplification helpers using trimesh."""
 
-import trimesh
+import importlib
+from functools import lru_cache
+
+
+@lru_cache(maxsize=1)
+def _trimesh():
+    return importlib.import_module("trimesh")
 
 
 def mesh_simplify(mesh_in: str, mesh_out: str, *, factor: float) -> None:
@@ -16,7 +22,9 @@ def mesh_simplify(mesh_in: str, mesh_out: str, *, factor: float) -> None:
         Fraction of faces to keep (0 < factor <= 1).
     """
 
-    mesh = trimesh.load(mesh_in, force="mesh")
+    tm = _trimesh()
+
+    mesh = tm.load(mesh_in, force="mesh")
     target_faces = max(int(len(mesh.faces) * factor), 4)
     simplified = mesh.simplify_quadratic_decimation(target_faces)
     simplified.export(mesh_out)

--- a/app/converters/step_to_mesh.py
+++ b/app/converters/step_to_mesh.py
@@ -1,11 +1,5 @@
 """STEP -> STL mesh conversion utilities."""
 
-from OCP.STEPControl import STEPControl_Reader
-from OCP.IFSelect import IFSelect_RetDone
-from OCP.BRepMesh import BRepMesh_IncrementalMesh
-from OCP.StlAPI import StlAPI_Writer
-
-
 def step_to_mesh(step_path: str, mesh_path: str, *, linear_defl: float, angular_defl: float) -> None:
     """Convert a STEP file to an STL mesh using OpenCascade.
 
@@ -20,6 +14,11 @@ def step_to_mesh(step_path: str, mesh_path: str, *, linear_defl: float, angular_
     angular_defl: float
         Angular deflection for tessellation in radians.
     """
+
+    from OCP.STEPControl import STEPControl_Reader
+    from OCP.IFSelect import IFSelect_RetDone
+    from OCP.BRepMesh import BRepMesh_IncrementalMesh
+    from OCP.StlAPI import StlAPI_Writer
 
     reader = STEPControl_Reader()
     status = reader.ReadFile(step_path)

--- a/app/dfm/adapters/step_loader.py
+++ b/app/dfm/adapters/step_loader.py
@@ -2,29 +2,46 @@
 
 from __future__ import annotations
 
+import importlib
 import os
 import tempfile
-from typing import Iterable, Tuple
+from functools import lru_cache
+from typing import Iterable, Tuple, TYPE_CHECKING
 
-import cadquery as cq
 import numpy as np
-import trimesh
+
+if TYPE_CHECKING:  # pragma: no cover
+    import cadquery
+    import trimesh
 
 
-def load_mesh(step_path: str, max_bytes: int = 100 * 1024 * 1024) -> Tuple[trimesh.Trimesh, bool]:
+@lru_cache(maxsize=1)
+def _cadquery():
+    return importlib.import_module("cadquery")
+
+
+@lru_cache(maxsize=1)
+def _trimesh():
+    return importlib.import_module("trimesh")
+
+
+def load_mesh(step_path: str, max_bytes: int = 100 * 1024 * 1024) -> Tuple["trimesh.Trimesh", bool]:
     """Charge un STEP et retourne un mesh Trimesh.
 
     Si le fichier dépasse ``max_bytes`` alors une décimation contrôlée est
     appliquée et le booléen ``low_res`` est positionné à ``True``.
     """
 
+    cq = _cadquery()
+    tm = _trimesh()
+
     workplane = cq.importers.importStep(step_path)
     with tempfile.NamedTemporaryFile(suffix=".stl", delete=False) as tmp:
         cq.exporters.export(workplane, tmp.name)
         stl_path = tmp.name
     try:
-        mesh = trimesh.load(stl_path, force="mesh")
-        if isinstance(mesh, trimesh.Scene):
+        mesh = tm.load(stl_path, force="mesh")
+        if isinstance(mesh, tm.Scene):
             if mesh.geometry:
                 mesh = next(iter(mesh.geometry.values()))
             else:  # pragma: no cover - STEP vide
@@ -41,10 +58,12 @@ def load_mesh(step_path: str, max_bytes: int = 100 * 1024 * 1024) -> Tuple[trime
             os.unlink(stl_path)
 
 
-def compute_thickness(mesh: trimesh.Trimesh, samples: int = 1000) -> Tuple[float, float, Iterable[Tuple[float, float, int]], list]:
+def compute_thickness(mesh: "trimesh.Trimesh", samples: int = 1000) -> Tuple[float, float, Iterable[Tuple[float, float, int]], list]:
     """Évalue l'épaisseur moyenne et minimale du maillage."""
 
-    points, faces = trimesh.sample.sample_surface(mesh, samples)
+    tm = _trimesh()
+
+    points, faces = tm.sample.sample_surface(mesh, samples)
     normals = mesh.face_normals[faces]
     origins = points - normals * 1e-3
     hits, ray_idx, _ = mesh.ray.intersects_location(origins, -normals, multiple_hits=False)
@@ -70,7 +89,7 @@ def compute_thickness(mesh: trimesh.Trimesh, samples: int = 1000) -> Tuple[float
     return avg, min_th, histogram, per_face_avg
 
 
-def compute_projected_area(mesh: trimesh.Trimesh, axis: Tuple[float, float, float]) -> float:
+def compute_projected_area(mesh: "trimesh.Trimesh", axis: Tuple[float, float, float]) -> float:
     """Surface projetée sur le plan perpendiculaire à ``axis``."""
 
     axis_v = np.asarray(axis, dtype=float)
@@ -81,7 +100,7 @@ def compute_projected_area(mesh: trimesh.Trimesh, axis: Tuple[float, float, floa
     return float(0.5 * np.linalg.norm(areas, axis=1).sum())
 
 
-def compute_draft(mesh: trimesh.Trimesh, axis: Tuple[float, float, float], min_deg: float) -> Tuple[float, list]:
+def compute_draft(mesh: "trimesh.Trimesh", axis: Tuple[float, float, float], min_deg: float) -> Tuple[float, list]:
     """Calcule le ratio de dépouille valide et retourne les faces hors tolérance."""
 
     axis_v = np.asarray(axis, dtype=float)
@@ -104,10 +123,12 @@ def compute_draft(mesh: trimesh.Trimesh, axis: Tuple[float, float, float], min_d
     return ok_ratio, issues
 
 
-def find_small_radii(mesh: trimesh.Trimesh, min_radius: float = 0.5) -> Tuple[float, list]:
+def find_small_radii(mesh: "trimesh.Trimesh", min_radius: float = 0.5) -> Tuple[float, list]:
     """Détecte les zones à faible rayon de courbure."""
 
-    curv = trimesh.curvature.discrete_gaussian_curvature_measure(
+    tm = _trimesh()
+
+    curv = tm.curvature.discrete_gaussian_curvature_measure(
         mesh, np.arange(len(mesh.vertices)), 1.0
     )
     with np.errstate(divide="ignore", invalid="ignore"):
@@ -127,7 +148,7 @@ def find_small_radii(mesh: trimesh.Trimesh, min_radius: float = 0.5) -> Tuple[fl
     return min_r, issues
 
 
-def detect_undercuts(mesh: trimesh.Trimesh, axis: Tuple[float, float, float]) -> list:
+def detect_undercuts(mesh: "trimesh.Trimesh", axis: Tuple[float, float, float]) -> list:
     """Renvoie les faces orientées contre l'axe de démoulage."""
 
     axis_v = np.asarray(axis, dtype=float)

--- a/app/jobs.py
+++ b/app/jobs.py
@@ -1,10 +1,17 @@
+import importlib
+import logging
 import os
 import time
-import logging
-import trimesh
+from functools import lru_cache
+
 from .converters.step_to_mesh import step_to_mesh
 from .converters.mesh_simplify import mesh_simplify
 from .converters.mesh_to_xkt import mesh_to_xkt
+
+
+@lru_cache(maxsize=1)
+def _trimesh():
+    return importlib.import_module("trimesh")
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -21,10 +28,12 @@ def generate_low_preview(step_path: str) -> str:
     xkt_path = os.path.join(OUTPUT_FOLDER, f"{base}_low.xkt")
 
     start = time.time()
+    tm = _trimesh()
+
     step_to_mesh(step_path, mesh_path, linear_defl=2.0, angular_defl=0.8)
-    before = len(trimesh.load(mesh_path, force="mesh").faces)
+    before = len(tm.load(mesh_path, force="mesh").faces)
     mesh_simplify(mesh_path, mesh_path, factor=0.2)
-    after = len(trimesh.load(mesh_path, force="mesh").faces)
+    after = len(tm.load(mesh_path, force="mesh").faces)
     mesh_to_xkt(mesh_path, xkt_path)
     duration = time.time() - start
     size = os.path.getsize(xkt_path)
@@ -47,10 +56,12 @@ def generate_full_model(step_path: str) -> str:
     xkt_path = os.path.join(OUTPUT_FOLDER, f"{base}_full.xkt")
 
     start = time.time()
+    tm = _trimesh()
+
     step_to_mesh(step_path, mesh_path, linear_defl=0.2, angular_defl=0.2)
-    before = len(trimesh.load(mesh_path, force="mesh").faces)
+    before = len(tm.load(mesh_path, force="mesh").faces)
     mesh_simplify(mesh_path, mesh_path, factor=0.9)
-    after = len(trimesh.load(mesh_path, force="mesh").faces)
+    after = len(tm.load(mesh_path, force="mesh").faces)
     mesh_to_xkt(mesh_path, xkt_path)
     duration = time.time() - start
     size = os.path.getsize(xkt_path)

--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,6 @@ services:
   - type: web
     name: cadlytics-web
     env: python
-    plan: starter
     envVars:
       - key: NODE_VERSION
         value: 20
@@ -22,15 +21,12 @@ services:
       npm run build
       python -m pip install --upgrade pip setuptools wheel
       python -m pip install --no-cache-dir --timeout 600 --retries 10 -r requirements-web.txt
-    startCommand: gunicorn app:app --workers 2 --threads 8 --timeout 120
+    startCommand: gunicorn web:app --workers 2 --threads 8 --timeout 120
 
   - type: worker
     name: cadlytics-worker
     env: python
-    plan: starter
     envVars:
-      - key: NODE_VERSION
-        value: 20
       - key: PIP_DEFAULT_TIMEOUT
         value: "600"
       - key: REDIS_URL
@@ -38,10 +34,6 @@ services:
           type: redis
           name: cadlytics-redis
           property: connectionString
-      - key: OUTPUT_BUCKET
-        value: ""
-      - key: OUTPUT_PREFIX
-        value: ""
     buildCommand: |
       python -m pip install --upgrade pip setuptools wheel
       python -m pip install --no-cache-dir --timeout 600 --retries 10 -r requirements-worker.txt
@@ -49,13 +41,9 @@ services:
       python - <<'PY'
       import os, redis
       from rq import Worker, Queue, Connection
-      url = os.environ['REDIS_URL']
-      r = redis.from_url(url)
-      with Connection(r):
-          Worker([Queue(os.environ.get('RQ_QUEUE','default'))]).work(burst=False)
+      r = redis.from_url(os.environ['REDIS_URL'])
+      with Connection(r): Worker([Queue(os.environ.get('RQ_QUEUE','default'))]).work(burst=False)
       PY
 
 databases:
   - name: cadlytics-redis
-    plan: starter
-    ipAllowList: []

--- a/xkt_converter.py
+++ b/xkt_converter.py
@@ -20,10 +20,18 @@ import shutil
 import subprocess
 import tempfile
 import logging
+import importlib
 from pathlib import Path
 from typing import Optional
 
-import cadquery as cq  # STEP -> STL
+_CQ = None
+
+
+def _cadquery():
+    global _CQ
+    if _CQ is None:
+        _CQ = importlib.import_module("cadquery")
+    return _CQ
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +65,8 @@ def _step_to_stl(step_path: str, stl_path: str, tolerance: float = 0.6) -> None:
     if not step.exists():
         raise FileNotFoundError(step)
     out.parent.mkdir(parents=True, exist_ok=True)
+
+    cq = _cadquery()
 
     logger.info("CadQuery import: %s", step)
     shape = cq.importers.importStep(str(step))


### PR DESCRIPTION
## Résumé
- expose les tâches Celery via des proxys légers pour ne plus importer `tasks.conversion` (CadQuery/Trimesh) au boot Flask
- bascule les blueprints et convertisseurs web sur des helpers qui chargent CadQuery/OCP/Trimesh à la demande
- factorise les utilitaires DFM/mesh pour cacher les imports lourds derrière des caches `importlib`
- configure `render.yaml` avec des services web/worker appuyés sur Redis et des installs pip prolongées

## Tests
- (non exécuté)


------
https://chatgpt.com/codex/tasks/task_e_68c91499f1748333a47dd3ad6458c444