### PR TITLE
Serve landing at root and add viewer page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -84,6 +84,7 @@
             <p class="lead" style="color: var(--brown-medium);">
                 {% if current_language == 'en' %}Upload your STEP files for complete DFM analysis and advanced 3D visualization{% else %}Téléchargez vos fichiers STEP pour une analyse DFM complète et une visualisation 3D avancée{% endif %}
             </p>
+            <a href="/app" class="btn btn-primary mt-2">Ouvrir l’application 3D</a>
         </div>
 
         <!-- Layout principal en deux colonnes -->

--- a/templates/viewer.html
+++ b/templates/viewer.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<html lang="fr">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <title>Visualisation 3D</title>
+    <link rel="stylesheet" href="/static/css/style.css" />
+    <style>
+      #viewerContainer { width:100%; min-height:420px; position:relative; }
+      .wrap { max-width:1200px; margin:24px auto; padding:0 16px; }
+      .grid { display:grid; grid-template-columns:360px 1fr; gap:24px; align-items:start; }
+      .card { background:#fff; border-radius:12px; padding:16px; box-shadow:0 6px 24px rgba(0,0,0,.06); }
+      .btn { padding:10px 16px; border:0; border-radius:10px; cursor:pointer; }
+      .btn-primary { background:#3b5b39; color:#fff; }
+    </style>
+  </head>
+  <body>
+    <div class="wrap">
+      <h1>Analyse & Visualisation 3D</h1>
+
+      <div class="grid">
+        <!-- Upload -->
+        <div class="card" data-dropzone>
+          <h3>Télécharger un fichier</h3>
+          <p>Formats : <code>.stp</code>, <code>.step</code> (max 50MB)</p>
+          <div style="display:flex; gap:8px; align-items:center; margin:12px 0;">
+            <input id="fileInput" type="file" accept=".stp,.step" hidden />
+            <button class="btn btn-primary" onclick="document.getElementById('fileInput').click()">CHOISIR UN FICHIER</button>
+            <button id="btnVisualiser" class="btn">VISUALISER</button>
+          </div>
+
+          <label for="toleranceSelect">Tolérance</label>
+          <select id="toleranceSelect" style="display:block; margin-top:6px;">
+            <option value="standard">Standard (0.1 mm)</option>
+          </select>
+        </div>
+
+        <!-- Viewer -->
+        <div class="card" style="padding:0;">
+          <div id="viewerContainer"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Bundle front (produit par ton build) -->
+    <script type="module" src="/static/dist/main.js" defer></script>
+  </body>
+</html>

--- a/web.py
+++ b/web.py
@@ -1,12 +1,30 @@
 # web.py — service WEB léger
 import os, uuid, shlex, subprocess
-from flask import Flask, request, jsonify, send_from_directory, abort
+from flask import Flask, request, jsonify, send_from_directory, abort, render_template
 from flask_cors import CORS
 from redis import Redis
 from rq import Queue
 
 app = Flask(__name__)
 CORS(app)
+
+
+@app.get("/")
+def index():
+    """Serve la page front compilée."""
+    return render_template("index.html")
+
+
+@app.get("/app")
+def app_viewer():
+    """Expose la page Viewer (upload + visualisation 3D)."""
+    return render_template("viewer.html")
+
+
+@app.get("/favicon.ico")
+def favicon():
+    """Retourne un statut vide pour éviter les 404 dans la console."""
+    return "", 204
 
 UPLOAD_FOLDER = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
 OUTPUT_FOLDER = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")


### PR DESCRIPTION
## Summary
- restore the landing markup in templates/index.html so the homepage is preserved
- introduce templates/viewer.html with the upload and viewer interface
- expose / and /app routes in web.py to serve the landing and the new viewer page
- add a CTA button on the landing that links to the 3D viewer app

## Testing
- pytest tests/test_boot.py

------
https://chatgpt.com/codex/tasks/task_e_68c92003e16c833393daa50be067b7bf