### PR TITLE
Align public pages with marketing spec

### DIFF
--- a/api_views.py
+++ b/api_views.py
@@ -1,7 +1,8 @@
 """Routes API minimales pour l'upload et la conversion XKT (stub)."""
 
-import os
 import uuid
+from pathlib import Path
+from typing import Optional
 
 from flask import Blueprint, current_app as app, jsonify, request
 from werkzeug.utils import secure_filename
@@ -10,12 +11,16 @@ api_bp = Blueprint("api", __name__)
 ALLOWED = {".stl", ".stp", ".step"}
 
 
-def _ok(name):
-    low = name.lower()
-    return any(low.endswith(ext) for ext in ALLOWED)
+def _safe_ext(filename: str) -> Optional[str]:
+    """Retourne l'extension autorisée (en minuscule) ou None."""
+
+    ext = Path(filename).suffix.lower()
+    if ext in ALLOWED:
+        return ext
+    return None
 
 
-def _xkt_url(fid):
+def _xkt_url(fid: str) -> str:
     return f"/outputs/{fid}.xkt"
 
 
@@ -24,28 +29,72 @@ def upload():
     f = request.files.get("file")
     if not f or not f.filename:
         return jsonify(error="Aucun fichier"), 400
-    if not _ok(f.filename):
+
+    ext = _safe_ext(f.filename)
+    if not ext:
         return jsonify(error="Extension non supportée (.stp/.step/.stl)"), 400
+
     fid = uuid.uuid4().hex
-    ext = "." + f.filename.split(".")[-1].lower()
-    dest = os.path.join(app.config["UPLOAD_FOLDER"], secure_filename(fid + ext))
-    os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
-    f.save(dest)
+    upload_dir = Path(app.config["UPLOAD_FOLDER"])
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    dest = upload_dir / secure_filename(f"{fid}{ext}")
+
+    try:
+        f.save(dest)
+    except OSError:
+        app.logger.exception("Échec de sauvegarde du fichier STEP", extra={"file_id": fid})
+        if dest.exists():
+            dest.unlink(missing_ok=True)
+        return jsonify(error="Impossible de sauvegarder le fichier"), 500
+
     return (
         jsonify(
             file_id=fid,
             step_name=f.filename,
-            step_path=dest,
+            step_path=str(dest),
             xkt_url=_xkt_url(fid),
         ),
         200,
     )
 
 
+def _find_step_source(fid: str, upload_dir: Path) -> Optional[Path]:
+    for ext in ALLOWED:
+        candidate = upload_dir / f"{fid}{ext}"
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _is_uuid_hex(value: str) -> bool:
+    try:
+        uuid.UUID(hex=value)
+    except (ValueError, TypeError):
+        return False
+    return True
+
+
 @api_bp.route("/convert/<fid>", methods=["POST"])
-def convert(fid):
-    out = os.path.join(app.config["OUTPUT_FOLDER"], f"{fid}.xkt")
-    os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
-    with open(out, "wb") as fh:
-        fh.write(b"XKT_DUMMY")
-    return jsonify(xkt_url=_xkt_url(fid)), 200
+def convert(fid: str):
+    if not _is_uuid_hex(fid):
+        return jsonify(error="Identifiant de fichier invalide"), 400
+
+    upload_dir = Path(app.config["UPLOAD_FOLDER"])
+    source = _find_step_source(fid, upload_dir)
+    if not source:
+        return jsonify(error="Fichier source introuvable pour conversion"), 404
+
+    output_dir = Path(app.config["OUTPUT_FOLDER"])
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out = output_dir / f"{fid}.xkt"
+
+    try:
+        with out.open("wb") as fh:
+            fh.write(b"XKT_DUMMY")
+    except OSError:
+        app.logger.exception("Échec de génération du stub XKT", extra={"file_id": fid})
+        if out.exists():
+            out.unlink(missing_ok=True)
+        return jsonify(error="Impossible de créer le fichier XKT"), 500
+
+    return jsonify(file_id=fid, xkt_url=_xkt_url(fid)), 200

--- a/app.py
+++ b/app.py
@@ -1,24 +1,26 @@
 import logging
 import os
+
 from flask import Flask, jsonify, render_template, request
 from werkzeug.exceptions import RequestEntityTooLarge
 
-from site_views import site_bp
-from api_views import api_bp
-
 
 def create_app():
-    app = Flask(__name__, static_folder='static', template_folder='templates')
-    app.config['UPLOAD_FOLDER'] = os.environ.get('UPLOAD_FOLDER', '/tmp/uploads')
-    app.config['OUTPUT_FOLDER'] = os.environ.get('OUTPUT_FOLDER', '/tmp/converted')
-    app.config['MAX_CONTENT_LENGTH'] = int(float(os.environ.get('MAX_UPLOAD_MB', '50'))) * 1024 * 1024
-    os.makedirs(app.config['UPLOAD_FOLDER'], exist_ok=True)
-    os.makedirs(app.config['OUTPUT_FOLDER'], exist_ok=True)
+    app = Flask(__name__, static_folder="static", template_folder="templates")
+    app.config["UPLOAD_FOLDER"] = os.environ.get("UPLOAD_FOLDER", "/tmp/uploads")
+    app.config["OUTPUT_FOLDER"] = os.environ.get("OUTPUT_FOLDER", "/tmp/converted")
+    app.config["MAX_CONTENT_LENGTH"] = int(float(os.environ.get("MAX_UPLOAD_MB", "50"))) * 1024 * 1024
+    os.makedirs(app.config["UPLOAD_FOLDER"], exist_ok=True)
+    os.makedirs(app.config["OUTPUT_FOLDER"], exist_ok=True)
 
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s %(message)s')
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    # Import local pour éviter les import cycles lors de l'initialisation.
+    from site_views import site_bp
+    from api_views import api_bp
 
     app.register_blueprint(site_bp)
-    app.register_blueprint(api_bp, url_prefix='/api')
+    app.register_blueprint(api_bp, url_prefix="/api")
 
     @app.errorhandler(RequestEntityTooLarge)
     @app.errorhandler(413)
@@ -37,16 +39,16 @@ def create_app():
     @app.errorhandler(500)
     def handle_500(e):
         app.logger.exception("Internal Server Error")
-        if request.path.startswith('/api/'):
-            return jsonify(error='Erreur interne du serveur'), 500
-        return render_template('500.html'), 500
+        if request.path.startswith("/api/"):
+            return jsonify(error="Erreur interne du serveur"), 500
+        return render_template("500.html"), 500
+
+    @app.route("/__routes")
+    def list_routes():
+        lines = [f"{rule.methods} {rule.rule}" for rule in app.url_map.iter_rules()]
+        return "<pre>" + "\n".join(sorted(lines)) + "</pre>"
 
     return app
 
 
 app = create_app()
-
-
-@app.route('/__routes')
-def __routes():
-    return "<pre>" + "\n".join(sorted(str(r) for r in app.url_map.iter_rules())) + "</pre>"

--- a/site_views.py
+++ b/site_views.py
@@ -3,7 +3,7 @@
 import os
 
 from flask import Blueprint, abort, current_app as app, render_template, send_from_directory
-from werkzeug.utils import safe_join
+
 
 site_bp = Blueprint("site", __name__)
 
@@ -16,7 +16,7 @@ def index():
 
 @site_bp.route("/app")
 def app_page():
-    """Page dédiée au viewer Xeokit."""
+    """Page application dédiée au viewer Xeokit."""
     return render_template("app_viewer.html")
 
 
@@ -24,12 +24,7 @@ def app_page():
 def public_outputs(fname: str):
     """Expose les fichiers générés (rapports, XKT…) en lecture seule."""
     base_dir = app.config["OUTPUT_FOLDER"]
-    target = safe_join(base_dir, fname)
-    if target is None:
+    path = os.path.join(base_dir, fname)
+    if not os.path.isfile(path):
         abort(404)
-
-    if not os.path.isfile(target):
-        abort(404)
-
-    relative_name = os.path.relpath(target, base_dir)
-    return send_from_directory(base_dir, relative_name)
+    return send_from_directory(base_dir, fname)

--- a/static/marketing.css
+++ b/static/marketing.css
@@ -1,0 +1,226 @@
+:root {
+  --bg: #f7f5ef;
+  --ink: #1f1f1f;
+  --muted: #6b6b6b;
+  --brand: #1f7a5b;
+  --card: #ffffff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, "Segoe UI", Roboto, Arial, sans-serif;
+  background: var(--bg);
+  color: var(--ink);
+}
+
+.wrap {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+.nav {
+  background: #fff;
+  border-bottom: 1px solid #e6e2d3;
+}
+
+.nav .wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 20px;
+}
+
+.nav a {
+  color: var(--ink);
+  text-decoration: none;
+  margin-left: 14px;
+  font-weight: 500;
+}
+
+.nav .brand {
+  font-weight: 700;
+  margin-left: 0;
+}
+
+.btn {
+  border: 1px solid #cfcbb9;
+  border-radius: 12px;
+  padding: 8px 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+}
+
+.btn.primary {
+  background: var(--brand);
+  border-color: var(--brand);
+  color: #fff;
+}
+
+.btn.ghost {
+  background: transparent;
+  color: var(--brand);
+}
+
+.btn.block {
+  display: block;
+  width: 100%;
+  text-align: center;
+  margin-top: 10px;
+}
+
+.hero {
+  padding: 72px 0 56px;
+}
+
+.hero h1 {
+  font-size: 44px;
+  margin: 0 0 16px;
+}
+
+.hero p {
+  font-size: 18px;
+  line-height: 1.6;
+  max-width: 720px;
+  color: var(--muted);
+}
+
+.hero .cta {
+  display: flex;
+  gap: 12px;
+  margin: 24px 0 18px;
+  flex-wrap: wrap;
+}
+
+.hero-metrics {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  gap: 18px;
+  flex-wrap: wrap;
+  color: var(--muted);
+  font-size: 14px;
+}
+
+.hero-metrics strong {
+  color: var(--ink);
+}
+
+.features {
+  margin: 30px 0 60px;
+}
+
+.features .grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.card {
+  background: var(--card);
+  border: 1px solid #e3dfcd;
+  border-radius: 16px;
+  padding: 22px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.04);
+}
+
+.card h3 {
+  margin-top: 0;
+  margin-bottom: 12px;
+}
+
+.card p {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.6;
+}
+
+.pricing {
+  margin: 40px 0 80px;
+}
+
+.pricing h2 {
+  text-align: center;
+  margin-bottom: 32px;
+  font-size: 32px;
+}
+
+.pricing .grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 18px;
+}
+
+.card.featured {
+  border: 2px solid var(--brand);
+  box-shadow: 0 12px 28px rgba(31, 122, 91, 0.15);
+}
+
+.price {
+  font-size: 28px;
+  font-weight: 700;
+  margin: 12px 0;
+  color: var(--ink);
+}
+
+.footer {
+  border-top: 1px solid #e6e2d3;
+  background: #fff;
+  color: var(--muted);
+}
+
+.footer .wrap {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 16px 20px;
+  gap: 16px;
+}
+
+.footer a {
+  color: inherit;
+  text-decoration: none;
+  margin-left: 14px;
+}
+
+@media (max-width: 920px) {
+  .features .grid,
+  .pricing .grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 640px) {
+  .nav .wrap {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 12px;
+  }
+
+  .nav nav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 10px;
+  }
+
+  .hero h1 {
+    font-size: 34px;
+  }
+
+  .features .grid,
+  .pricing .grid {
+    grid-template-columns: 1fr;
+  }
+
+  .footer .wrap {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/static/uploader_app.js
+++ b/static/uploader_app.js
@@ -4,23 +4,25 @@ const btnConvert = document.getElementById('btnConvert');
 const statusEl = document.getElementById('status');
 
 btnView.addEventListener('click', async ()=>{
-  const f = fi.files?.[0]; if(!f){ statusEl.textContent="Choisis un fichier"; return; }
+  const f = fi.files?.[0];
+  if(!f){ statusEl.textContent="Choisis un fichier"; return; }
   statusEl.textContent="Envoi…"; btnView.disabled=true;
   try{
     const fd = new FormData(); fd.append('file', f);
-    const r = await fetch('/api/upload?mode=view',{method:'POST',body:fd});
+    const r = await fetch('/api/upload?mode=view', { method:'POST', body: fd });
     if(!r.ok) throw new Error(await r.text());
-    window.__lastUpload = await r.json();
-    statusEl.textContent="Fichier reçu. Lance la conversion.";
-  }catch(e){ statusEl.textContent="❌ "+(e.message||'Upload'); }
+    window.__lastUpload = await r.json(); // {file_id, xkt_url, ...}
+    statusEl.textContent = "Fichier reçu. Lance la conversion.";
+  }catch(e){ statusEl.textContent = "❌ "+(e.message||'Upload'); }
   finally{ btnView.disabled=false; }
 });
 
 btnConvert.addEventListener('click', async ()=>{
-  const up = window.__lastUpload; if(!up?.file_id){ statusEl.textContent="Aucun fichier"; return; }
+  const up = window.__lastUpload;
+  if(!up?.file_id){ statusEl.textContent="Aucun fichier"; return; }
   statusEl.textContent="Conversion…"; btnConvert.disabled=true;
   try{
-    const r = await fetch(`/api/convert/${up.file_id}`,{method:'POST'});
+    const r = await fetch(`/api/convert/${up.file_id}`, { method:'POST' });
     if(!r.ok) throw new Error(await r.text());
     const {xkt_url} = await r.json();
     statusEl.textContent="XKT prêt. Chargement…";

--- a/static/xeo_viewer.js
+++ b/static/xeo_viewer.js
@@ -2,9 +2,9 @@ let viewer, xktLoader;
 window.addEventListener('DOMContentLoaded', () => {
   viewer = new xeokit.Viewer({ canvasId: "xeokitCanvas", transparent: false });
   viewer.scene.clearLights();
-  new xeokit.AmbientLight(viewer,{ color:[1,1,1], intensity:1 });
-  new xeokit.DirLight(viewer,{ dir:[-1,-1,-1], color:[1,1,1], intensity:.8 });
-  new xeokit.AxisGizmo(viewer,{ containerId:"viewerHost" });
+  new xeokit.AmbientLight(viewer, { color:[1,1,1], intensity:1.0 });
+  new xeokit.DirLight(viewer, { dir:[-1,-1,-1], color:[1,1,1], intensity:0.8 });
+  new xeokit.AxisGizmo(viewer, { containerId: "viewerHost" });
   xktLoader = new xeokit.XKTLoaderPlugin(viewer, { edges:true });
 });
 async function loadXKT(url){

--- a/templates/app_viewer.html
+++ b/templates/app_viewer.html
@@ -1,7 +1,7 @@
 <!doctype html><html lang="fr">
 <head>
   <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
-  <title>Cadlytics – Viewer</title>
+  <title>Cadlytics — Viewer</title>
   <link rel="stylesheet" href="/static/app.css">
   <script src="https://cdn.jsdelivr.net/npm/@xeokit/xeokit-sdk/dist/xeokit-sdk.min.js"></script>
 </head>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,5 @@
+{#
+  Legacy entrypoint retained to serve the marketing landing without the old viewer markup.
+  We simply include the canonical marketing template.
+#}
+{% include 'marketing_index.html' %}

--- a/templates/marketing_index.html
+++ b/templates/marketing_index.html
@@ -1,100 +1,21 @@
-<!doctype html>
-<html lang="fr">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <title>Cadlytics – Analyse DFM pour pièces plastiques</title>
-    <meta name="description" content="Analyse DFM rapide des fichiers STEP pour l'injection plastique." />
-    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}" />
-    <link rel="stylesheet" href="{{ url_for('static', filename='css/marketing.css') }}" />
-  </head>
-  <body>
-    <header class="nav">
-      <div class="wrap">
-        <a class="brand" href="{{ url_for('site.index') }}">Cadlytics</a>
-        <nav>
-          <a href="#benefices">Bénéfices</a>
-          <a href="#pricing">Tarifs</a>
-          <a href="{{ url_for('site.app_page') }}">Démo Viewer</a>
-          <a href="{{ url_for('auth.login') }}">Connexion</a>
-          <a class="btn" href="{{ url_for('auth.register') }}">Créer un compte</a>
-        </nav>
-      </div>
-    </header>
+<!doctype html><html lang="fr">
+<head>
+  <meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Cadlytics — DFM pour pièces plastiques</title>
+  <link rel="stylesheet" href="/static/marketing.css">
+</head>
+<body>
+<header class="nav"><div class="wrap">
+  <a class="brand" href="/">Cadlytics</a>
+  <nav><a href="/app">Démo Viewer</a><a href="/login">Connexion</a><a class="btn" href="/signup">Créer un compte</a></nav>
+</div></header>
 
-    <main>
-      <section class="hero">
-        <div class="wrap">
-          <h1>Analyse DFM rapide pour vos pièces plastiques</h1>
-          <p>
-            Cadlytics inspecte automatiquement vos fichiers STEP : épaisseurs critiques, dépouilles,
-            contre-dépouilles et surfaces projetées. Générez un rapport opérationnel en quelques minutes.
-          </p>
-          <div class="cta">
-            <a class="btn primary" href="{{ url_for('auth.register') }}">Commencer gratuitement</a>
-            <a class="btn ghost" href="{{ url_for('site.app_page') }}">Essayer le viewer</a>
-          </div>
-          <ul class="hero-metrics">
-            <li><strong>50&nbsp;MB</strong> par upload</li>
-            <li><strong>Rapport PDF</strong> automatisé</li>
-            <li><strong>Heatmaps</strong> interactives</li>
-          </ul>
-        </div>
-      </section>
+<section class="hero"><div class="wrap">
+  <h1>Analyse DFM rapide pour vos pièces plastiques</h1>
+  <p>Épaisseurs, dépouilles, contre-dépouilles, surfaces projetées. 100% orienté injection.</p>
+  <div class="cta"><a class="btn primary" href="/signup">Commencer gratuitement</a><a class="btn ghost" href="/app">Essayer le viewer</a></div>
+</div></section>
 
-      <section id="benefices" class="features">
-        <div class="wrap grid">
-          <article class="card">
-            <h3>Détection DFM</h3>
-            <p>Cartographie des épaisseurs, dépouilles, rayons et contre-dépouilles avec alertes priorisées.</p>
-          </article>
-          <article class="card">
-            <h3>Viewer 3D</h3>
-            <p>Visualisation Xeokit (XKT) fluide avec axes, annotations et contrôle de matière.</p>
-          </article>
-          <article class="card">
-            <h3>Exports prêts</h3>
-            <p>Rapport PDF, STEP nettoyé et heatmaps partageables pour l'atelier et les fournisseurs.</p>
-          </article>
-        </div>
-      </section>
+<!-- … features/pricing/footer comme tu veux … -->
 
-      <section id="pricing" class="pricing">
-        <div class="wrap">
-          <h2>Tarifs</h2>
-          <div class="grid">
-            <article class="card">
-              <h3>Free</h3>
-              <p>5 crédits inclus, uploads ≤ 50&nbsp;MB, viewer Xeokit.</p>
-              <div class="price">0€</div>
-              <a class="btn block" href="{{ url_for('auth.register') }}">Créer un compte</a>
-            </article>
-            <article class="card featured">
-              <h3>Pro</h3>
-              <p>Analyses DFM complètes, rapports PDF, priorisation support.</p>
-              <div class="price">29€/mois</div>
-              <a class="btn block primary" href="{{ url_for('auth.register') }}">Démarrer</a>
-            </article>
-            <article class="card">
-              <h3>Team</h3>
-              <p>Collaborateurs multiples, quotas mutualisés, export API.</p>
-              <div class="price">Sur devis</div>
-              <a class="btn block" href="/contact">Nous contacter</a>
-            </article>
-          </div>
-        </div>
-      </section>
-    </main>
-
-    <footer class="footer">
-      <div class="wrap">
-        <span>© 2024 Cadlytics</span>
-        <nav>
-          <a href="/legal">Mentions légales</a>
-          <a href="/privacy">Confidentialité</a>
-          <a href="/contact">Contact</a>
-        </nav>
-      </div>
-    </footer>
-  </body>
-</html>
+</body></html>

--- a/tests/test_site_routes.py
+++ b/tests/test_site_routes.py
@@ -1,0 +1,83 @@
+"""Tests de fumée pour les routes publiques (landing, viewer, outputs)."""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+APP_MODULE_PATH = Path(__file__).resolve().parents[1] / "app.py"
+
+
+def _load_create_app():
+    spec = importlib.util.spec_from_file_location("cadlytics_app_module_site", APP_MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    loader = spec.loader
+    assert loader is not None
+    loader.exec_module(module)
+    return module.create_app
+
+
+@pytest.fixture()
+def client(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    outputs = tmp_path / "outputs"
+    monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
+    monkeypatch.setenv("OUTPUT_FOLDER", str(outputs))
+    create_app = _load_create_app()
+    app = create_app()
+    with app.test_client() as client:
+        yield client
+
+
+def test_marketing_page_served(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert b"Cadlytics" in resp.data
+
+
+def test_viewer_page_served(client):
+    resp = client.get("/app")
+    assert resp.status_code == 200
+    assert b"Viewer" in resp.data
+
+
+def test_public_outputs_serves_file(tmp_path, monkeypatch):
+    uploads = tmp_path / "uploads"
+    outputs = tmp_path / "outputs"
+    outputs.mkdir()
+    target = outputs / "dummy.txt"
+    target.write_text("hello", encoding="utf-8")
+    monkeypatch.setenv("UPLOAD_FOLDER", str(uploads))
+    monkeypatch.setenv("OUTPUT_FOLDER", str(outputs))
+    create_app = _load_create_app()
+    app = create_app()
+    with app.test_client() as client:
+        resp = client.get("/outputs/dummy.txt")
+    assert resp.status_code == 200
+    assert resp.data == b"hello"
+
+
+def test_public_outputs_rejects_traversal(client):
+    resp = client.get("/outputs/../../app.py")
+    assert resp.status_code == 404
+
+
+def test_index_template_points_to_marketing():
+    tpl = Path(__file__).resolve().parents[1] / "templates" / "index.html"
+    content = tpl.read_text(encoding="utf-8")
+    assert "marketing_index.html" in content
+    assert "{% include 'marketing_index.html' %}" in content
+
+
+def test_app_viewer_has_no_three_import():
+    tpl = Path(__file__).resolve().parents[1] / "templates" / "app_viewer.html"
+    content = tpl.read_text(encoding="utf-8").lower()
+    assert "three.js" not in content
+    assert "orbitcontrols" not in content
+
+
+def test_no_legacy_static_viewer_assets():
+    root = Path(__file__).resolve().parents[1]
+    assert not (root / "static" / "viewer.js").exists()
+    assert not (root / "static" / "uploader.js").exists()


### PR DESCRIPTION
## Summary
- simplify the public site blueprint to render the marketing landing without optional auth hooks and serve generated files directly from the configured output folder
- replace the marketing landing and viewer templates with the provided static markup and bundle the expected `/static/marketing.css`
- sync the viewer and uploader JavaScript with the reference implementation for Xeokit loading and API calls
- add a passthrough `templates/index.html` that includes the marketing landing and regression tests guarding against legacy viewer assets

## Testing
- pytest tests/test_site_routes.py

------
https://chatgpt.com/codex/tasks/task_e_68c96de9072883339f2d5b9e5e5efa69