### PR TITLE
Use DFM outputs in reports

### DIFF
--- a/jobs/dfm_runner.py
+++ b/jobs/dfm_runner.py
@@ -117,30 +117,28 @@ def _worker(
         out_dir = os.path.join(DFM_ROOT, file_id)
         os.makedirs(out_dir, exist_ok=True)
         json_path = os.path.join(out_dir, "result.json")
+        result_payload = result.model_dump() if hasattr(result, "model_dump") else result.__dict__
         with open(json_path, "w", encoding="utf-8") as fh:
-            fh.write(result.model_dump_json(indent=2))
+            json.dump(result_payload, fh, indent=2)
         report_path = os.path.join(out_dir, "report.json")
+        heatmap_file = os.path.join(out_dir, "heatmap_faces.json")
         report_data = {
             "status": "done",
-            "score": 72,
-            "recommendations": [
-                {
-                    "id": "thickness_uniformity",
-                    "level": "warning",
-                    "message": "Épaisseur non uniforme.",
-                }
-            ],
-            "metrics": {
-                "min_thickness_mm": 1.2,
-                "max_thickness_mm": 3.8,
-                "avg_thickness_mm": 2.4,
-                "undercuts_count": 2,
-            },
+            "metrics": result.metrics,
+            "issues": result.issues,
+            "heatmaps": result.heatmaps,
+            "views": result.views,
+            "flags": result.flags,
+            "material_profile_id": material_profile.get("id"),
+            "axis": demold_axis,
+            "invert": False,
+            "step_path": step_path,
+            "heatmap_files": {"faces": heatmap_file} if os.path.isfile(heatmap_file) else {},
         }
         with open(report_path, "w", encoding="utf-8") as fh:
             json.dump(report_data, fh)
         logger.info("DFM written \u2192 %s", report_path)
-        job.update(status="done", progress=100, result=result.model_dump())
+        job.update(status="done", progress=100, result=result_payload)
         rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024
         logger.info("dfm job %s done in %.2fs rss=%.1fMB", job_id, time.perf_counter() - t0, rss)
     except Exception as exc:  # pragma: no cover - error paths hard to trigger in tests

--- a/tasks/dfm.py
+++ b/tasks/dfm.py
@@ -44,7 +44,7 @@ def dfm_run(self, file_id, material_profile_id, axis, invert=False, tolerance=No
 
     # Generate viewer artefacts (heatmaps, thumbnails...)
     try:
-        run_dfm(dfm_input, progress_cb=None, fast_mode=False)
+        result = run_dfm(dfm_input, progress_cb=None, fast_mode=False)
     except Exception as exc:  # pragma: no cover - artefact generation is best effort
         logger.exception("[DFM] run_dfm failed for file_id=%s", file_id)
         error_report = {
@@ -54,23 +54,21 @@ def dfm_run(self, file_id, material_profile_id, axis, invert=False, tolerance=No
         _write_report(error_report)
         raise
 
-    # Aggregate a minimal DFM report
+    heatmap_file = os.path.join(out_dir, "heatmap_faces.json")
+
+    # Aggregate a DFM report based on the computed results
     report_data = {
         "status": "done",
-        "score": 72,
-        "recommendations": [
-            {
-                "id": "thickness_uniformity",
-                "level": "warning",
-                "message": "Épaisseur non uniforme.",
-            }
-        ],
-        "metrics": {
-            "min_thickness_mm": 1.2,
-            "max_thickness_mm": 3.8,
-            "avg_thickness_mm": 2.4,
-            "undercuts_count": 2,
-        },
+        "metrics": result.metrics,
+        "issues": result.issues,
+        "heatmaps": result.heatmaps,
+        "views": result.views,
+        "flags": result.flags,
+        "material_profile_id": material_profile_id,
+        "axis": axis,
+        "invert": invert,
+        "step_path": step_path,
+        "heatmap_files": {"faces": heatmap_file} if os.path.isfile(heatmap_file) else {},
     }
 
     _write_report(report_data)

--- a/tests/test_dfm_report.py
+++ b/tests/test_dfm_report.py
@@ -1,0 +1,34 @@
+import json
+import os
+import pathlib
+import shutil
+
+from tasks import dfm
+from app.storage import storage
+
+
+def test_dfm_report_contains_results_and_assets(monkeypatch):
+    file_id = "reportjson"
+    step_path = os.path.join(os.path.dirname(__file__), "sample.step")
+    out_dir = pathlib.Path("static") / "dfm" / file_id
+    shutil.rmtree(out_dir, ignore_errors=True)
+
+    monkeypatch.setattr(storage.Storage, "get_step_path", lambda _file_id: step_path)
+
+    report = dfm.dfm_run.run(file_id, "GENERIC", (0.0, 0.0, 1.0), False)
+
+    report_path = out_dir / "report.json"
+    data = json.loads(report_path.read_text())
+
+    assert data["metrics"]["bounding_box"] == report["metrics"]["bounding_box"]
+    assert set(data["metrics"]["bounding_box"].keys()) == {"x", "y", "z"}
+    assert data["material_profile_id"] == "GENERIC"
+    assert tuple(data["axis"]) == (0.0, 0.0, 1.0)
+    assert data["invert"] is False
+    assert data["step_path"] == step_path
+
+    for thumb_path in data["views"]["thumbnails"].values():
+        assert pathlib.Path(thumb_path).is_file()
+
+    heatmap_path = data.get("heatmap_files", {}).get("faces") or str(out_dir / "heatmap_faces.json")
+    assert pathlib.Path(heatmap_path).is_file()


### PR DESCRIPTION
## Summary
- replace the static DFM report payloads with the metrics, views, heatmaps, and flags returned by `run_dfm`
- include traceability information such as material profile, axis, inversion, and step path in the generated reports
- add a regression test to assert report.json stores computed metrics and references existing thumbnail/heatmap assets

## Testing
- pytest tests/test_dfm.py tests/test_dfm_report.py


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69440090617c8333a14e77c8a7256cab)